### PR TITLE
Add gitignore and setup docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Node modules
+node_modules/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Build output
+/dist/
+/build/
+
+# Runtime data
+pids
+*.pid
+*.seed
+
+# dotenv environment variables
+.env
+.env.local
+.env.*.local
+
+# Editor directories and files
+.idea/
+.vscode/
+
+# OS generated files
+.DS_Store
+Thumbs.db
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Web Site Jedziniak
+
+A simple static web site served using Node.js tools.
+
+## Getting Started
+
+1. Install [Node.js](https://nodejs.org/) if you don't already have it.
+2. Install project dependencies:
+   ```bash
+   npm install
+   ```
+   (There are currently no dependencies, but this prepares `node_modules` if packages are added.)
+3. Start a local server to view the site:
+   ```bash
+   npx http-server .
+   ```
+   Then open [http://localhost:8080](http://localhost:8080) in your browser.
+
+


### PR DESCRIPTION
## Summary
- add a gitignore tailored for Node projects
- document how to install dependencies and run the site

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_685534d49a848324b74d0c17ae81a3ee