### PR TITLE
Add responsive offer section

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -87,6 +87,40 @@ body {
   text-align: center;
 }
 
+/* Oferta */
+.offer {
+  text-align: center;
+}
+.offer h3 {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+.offer-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.offer-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--light);
+  padding: 3rem 1rem;
+  border-radius: 8px;
+  text-decoration: none;
+  color: inherit;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.offer-item:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
+
 /* Galeria */
 .gallery h3 {
   text-align: center;

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,6 +20,16 @@
     </div>
   </header>
 
+  <section id="offer" class="offer section reveal">
+    <h3>Oferta</h3>
+    <div class="offer-grid">
+      <a href="kuchnia.html" class="offer-item"><h4>Kuchnia</h4></a>
+      <a href="salon.html" class="offer-item"><h4>Salon</h4></a>
+      <a href="lazienka.html" class="offer-item"><h4>Łazienka</h4></a>
+      <a href="inne.html" class="offer-item"><h4>Inne</h4></a>
+    </div>
+  </section>
+
   <section id="about" class="about section reveal">
     <div class="container">
       <h3>O nas</h3>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -27,15 +27,17 @@ const images = [
 ];
 
 const grid = document.getElementById('gallery-grid');
-images.forEach(({ src, alt }) => {
-  const fig = document.createElement('figure');
-  fig.className = 'item';
-  const img = document.createElement('img');
-  img.src = src;
-  img.alt = alt;
-  fig.appendChild(img);
-  grid.appendChild(fig);
-});
+if (grid) {
+  images.forEach(({ src, alt }) => {
+    const fig = document.createElement('figure');
+    fig.className = 'item';
+    const img = document.createElement('img');
+    img.src = src;
+    img.alt = alt;
+    fig.appendChild(img);
+    grid.appendChild(fig);
+  });
+}
 
 // Animacja pojawiania się sekcji
 const observer = new IntersectionObserver((entries) => {


### PR DESCRIPTION
## Summary
- add "Oferta" section with four linked tiles
- style offer tiles with responsive grid and hover effect
- guard gallery script so it runs only when gallery present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc4e36bf1083249afa810590812ba6