### PR TITLE
Add category pages with dedicated gallery scripts

### DIFF
--- a/docs/inne.html
+++ b/docs/inne.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vikimeble - Inne</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./css/styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <nav class="nav">
+      <h1 class="logo"><img src="./images/logo.png" alt="Vikimeble logo" /></h1>
+      <a href="index.html#contact" class="btn nav-cta">Kontakt</a>
+    </nav>
+    <div class="hero-content">
+      <h2>Tworzymy meble, które kochasz</h2>
+      <p>Designerskie projekty z naturalnego drewna prosto z naszej pracowni.</p>
+      <a href="#gallery-grid" class="btn cta">Zobacz ofertę</a>
+    </div>
+  </header>
+
+  <div id="gallery-grid"></div>
+
+  <footer class="footer">
+    <p>&copy; 2024 Vikimeble</p>
+    <a href="admin/login.html">Panel administracyjny</a>
+  </footer>
+
+  <script src="./js/inne.js"></script>
+</body>
+</html>

--- a/docs/js/inne.js
+++ b/docs/js/inne.js
@@ -1,0 +1,40 @@
+// Generowanie galerii obrazów dla innych mebli
+const images = [
+  { src: 'https://picsum.photos/id/40/800/600', alt: 'Szafa na zamówienie' },
+  { src: 'https://picsum.photos/id/41/800/600', alt: 'Biurko z drewna' },
+  { src: 'https://picsum.photos/id/42/800/600', alt: 'Łóżko drewniane' },
+  { src: 'https://picsum.photos/id/43/800/600', alt: 'Regał na książki' }
+];
+
+const grid = document.getElementById('gallery-grid');
+images.forEach(({ src, alt }) => {
+  const fig = document.createElement('figure');
+  fig.className = 'item';
+  const img = document.createElement('img');
+  img.src = src;
+  img.alt = alt;
+  fig.appendChild(img);
+  grid.appendChild(fig);
+});
+
+// Animacja pojawiania się sekcji
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('active');
+      observer.unobserve(entry.target);
+    }
+  });
+}, { threshold: 0.1 });
+
+document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+
+// Obsługa formularza kontaktowego
+const form = document.querySelector('.contact-form');
+if (form) {
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    alert('Dziękujemy za wiadomość!');
+    form.reset();
+  });
+}

--- a/docs/js/kuchnia.js
+++ b/docs/js/kuchnia.js
@@ -1,0 +1,40 @@
+// Generowanie galerii obrazów dla kuchni
+const images = [
+  { src: 'https://picsum.photos/id/10/800/600', alt: 'Nowoczesna kuchnia z drewnem' },
+  { src: 'https://picsum.photos/id/11/800/600', alt: 'Szafki kuchenne' },
+  { src: 'https://picsum.photos/id/12/800/600', alt: 'Wyspa kuchenna' },
+  { src: 'https://picsum.photos/id/13/800/600', alt: 'Blat z naturalnego drewna' }
+];
+
+const grid = document.getElementById('gallery-grid');
+images.forEach(({ src, alt }) => {
+  const fig = document.createElement('figure');
+  fig.className = 'item';
+  const img = document.createElement('img');
+  img.src = src;
+  img.alt = alt;
+  fig.appendChild(img);
+  grid.appendChild(fig);
+});
+
+// Animacja pojawiania się sekcji
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('active');
+      observer.unobserve(entry.target);
+    }
+  });
+}, { threshold: 0.1 });
+
+document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+
+// Obsługa formularza kontaktowego
+const form = document.querySelector('.contact-form');
+if (form) {
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    alert('Dziękujemy za wiadomość!');
+    form.reset();
+  });
+}

--- a/docs/js/lazienka.js
+++ b/docs/js/lazienka.js
@@ -1,0 +1,40 @@
+// Generowanie galerii obrazów dla łazienki
+const images = [
+  { src: 'https://picsum.photos/id/30/800/600', alt: 'Minimalistyczna łazienka' },
+  { src: 'https://picsum.photos/id/31/800/600', alt: 'Umywalka z szafką' },
+  { src: 'https://picsum.photos/id/32/800/600', alt: 'Wanna wolnostojąca' },
+  { src: 'https://picsum.photos/id/33/800/600', alt: 'Szafka na ręczniki' }
+];
+
+const grid = document.getElementById('gallery-grid');
+images.forEach(({ src, alt }) => {
+  const fig = document.createElement('figure');
+  fig.className = 'item';
+  const img = document.createElement('img');
+  img.src = src;
+  img.alt = alt;
+  fig.appendChild(img);
+  grid.appendChild(fig);
+});
+
+// Animacja pojawiania się sekcji
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('active');
+      observer.unobserve(entry.target);
+    }
+  });
+}, { threshold: 0.1 });
+
+document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+
+// Obsługa formularza kontaktowego
+const form = document.querySelector('.contact-form');
+if (form) {
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    alert('Dziękujemy za wiadomość!');
+    form.reset();
+  });
+}

--- a/docs/js/salon.js
+++ b/docs/js/salon.js
@@ -1,0 +1,40 @@
+// Generowanie galerii obrazów dla salonu
+const images = [
+  { src: 'https://picsum.photos/id/20/800/600', alt: 'Stylowy salon' },
+  { src: 'https://picsum.photos/id/21/800/600', alt: 'Kanapa w salonie' },
+  { src: 'https://picsum.photos/id/22/800/600', alt: 'Stolik kawowy' },
+  { src: 'https://picsum.photos/id/23/800/600', alt: 'Półka na książki' }
+];
+
+const grid = document.getElementById('gallery-grid');
+images.forEach(({ src, alt }) => {
+  const fig = document.createElement('figure');
+  fig.className = 'item';
+  const img = document.createElement('img');
+  img.src = src;
+  img.alt = alt;
+  fig.appendChild(img);
+  grid.appendChild(fig);
+});
+
+// Animacja pojawiania się sekcji
+const observer = new IntersectionObserver((entries) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      entry.target.classList.add('active');
+      observer.unobserve(entry.target);
+    }
+  });
+}, { threshold: 0.1 });
+
+document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+
+// Obsługa formularza kontaktowego
+const form = document.querySelector('.contact-form');
+if (form) {
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    alert('Dziękujemy za wiadomość!');
+    form.reset();
+  });
+}

--- a/docs/kuchnia.html
+++ b/docs/kuchnia.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vikimeble - Kuchnia</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./css/styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <nav class="nav">
+      <h1 class="logo"><img src="./images/logo.png" alt="Vikimeble logo" /></h1>
+      <a href="index.html#contact" class="btn nav-cta">Kontakt</a>
+    </nav>
+    <div class="hero-content">
+      <h2>Tworzymy meble, które kochasz</h2>
+      <p>Designerskie projekty z naturalnego drewna prosto z naszej pracowni.</p>
+      <a href="#gallery-grid" class="btn cta">Zobacz ofertę</a>
+    </div>
+  </header>
+
+  <div id="gallery-grid"></div>
+
+  <footer class="footer">
+    <p>&copy; 2024 Vikimeble</p>
+    <a href="admin/login.html">Panel administracyjny</a>
+  </footer>
+
+  <script src="./js/kuchnia.js"></script>
+</body>
+</html>

--- a/docs/lazienka.html
+++ b/docs/lazienka.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vikimeble - Łazienka</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./css/styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <nav class="nav">
+      <h1 class="logo"><img src="./images/logo.png" alt="Vikimeble logo" /></h1>
+      <a href="index.html#contact" class="btn nav-cta">Kontakt</a>
+    </nav>
+    <div class="hero-content">
+      <h2>Tworzymy meble, które kochasz</h2>
+      <p>Designerskie projekty z naturalnego drewna prosto z naszej pracowni.</p>
+      <a href="#gallery-grid" class="btn cta">Zobacz ofertę</a>
+    </div>
+  </header>
+
+  <div id="gallery-grid"></div>
+
+  <footer class="footer">
+    <p>&copy; 2024 Vikimeble</p>
+    <a href="admin/login.html">Panel administracyjny</a>
+  </footer>
+
+  <script src="./js/lazienka.js"></script>
+</body>
+</html>

--- a/docs/salon.html
+++ b/docs/salon.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="pl">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Vikimeble - Salon</title>
+  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./css/styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <nav class="nav">
+      <h1 class="logo"><img src="./images/logo.png" alt="Vikimeble logo" /></h1>
+      <a href="index.html#contact" class="btn nav-cta">Kontakt</a>
+    </nav>
+    <div class="hero-content">
+      <h2>Tworzymy meble, które kochasz</h2>
+      <p>Designerskie projekty z naturalnego drewna prosto z naszej pracowni.</p>
+      <a href="#gallery-grid" class="btn cta">Zobacz ofertę</a>
+    </div>
+  </header>
+
+  <div id="gallery-grid"></div>
+
+  <footer class="footer">
+    <p>&copy; 2024 Vikimeble</p>
+    <a href="admin/login.html">Panel administracyjny</a>
+  </footer>
+
+  <script src="./js/salon.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Copy index layout into separate room pages (kuchnia, salon, łazienka, inne) keeping shared header/footer and gallery placeholders.
- Implement per-room JavaScript files that populate galleries with category-specific images and reuse main logic.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc4e39966c832484607ecfc6779764