### PR TITLE
docs: document admin password configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment configuration
+ADMIN_PASSWORD=admin
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Web Site Jedziniak
+
+Domyślne hasło administratora to **admin**.
+
+Aby ustawić własne hasło, ustaw zmienną środowiskową `ADMIN_PASSWORD` przed uruchomieniem aplikacji, np.:
+
+```bash
+export ADMIN_PASSWORD=moje_haslo
+npm start
+```
+
+Możesz również skopiować plik `.env.example` do `.env` i w nim ustawić wartość `ADMIN_PASSWORD`.
+


### PR DESCRIPTION
## Summary
- add README with default admin password and instructions to set ADMIN_PASSWORD env var
- provide `.env.example` for easy configuration

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4280890f883249b935cdea98a63f2