### PR TITLE
Redirect admin login directly to dashboard

### DIFF
--- a/docs/admin/login.html
+++ b/docs/admin/login.html
@@ -2,23 +2,15 @@
 <html lang="pl">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Logowanie administratora</title>
-  <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+  <meta http-equiv="refresh" content="0; url=dashboard.html" />
+  <title>Przekierowanie</title>
   <link rel="stylesheet" href="../css/styles.css" />
 </head>
 <body>
-  <nav class="nav">
-    <h1 class="logo"><a href="../index.html"><img src="../images/logo.png" alt="Vikimeble logo" /></a></h1>
-    <a href="../index.html#gallery" class="btn">Galeria</a>
-    <a href="../index.html#contact" class="btn nav-cta">Kontakt</a>
-  </nav>
-  <main>
-    <h2>Panel administracyjny - logowanie</h2>
-    <form method="POST" action="/api/login">
-      <label>Hasło: <input type="password" name="password" required></label>
-      <button type="submit">Zaloguj</button>
-    </form>
-  </main>
+  <p>Trwa przekierowywanie do panelu administracyjnego...</p>
+  <script>
+    window.location.href = 'dashboard.html';
+  </script>
 </body>
 </html>
+

--- a/docs/index.html
+++ b/docs/index.html
@@ -77,7 +77,7 @@
 
   <footer class="footer">
     <p>&copy; <span id="year"></span> Vikimeble</p>
-    <a href="admin/login.html">Panel administracyjny</a>
+    <a href="admin/dashboard.html">Panel administracyjny</a>
   </footer>
 
   <script src="./js/main.js"></script>

--- a/docs/inne.html
+++ b/docs/inne.html
@@ -31,7 +31,7 @@
   </main>
   <footer class="footer">
     <p>&copy; <span id="year"></span> Vikimeble</p>
-    <a href="admin/login.html">Panel administracyjny</a>
+    <a href="admin/dashboard.html">Panel administracyjny</a>
   </footer>
   <script src="./js/inne.js"></script>
 </body>

--- a/docs/kuchnia.html
+++ b/docs/kuchnia.html
@@ -29,7 +29,7 @@
 
   <footer class="footer">
     <p>&copy; <span id="year"></span> Vikimeble</p>
-    <a href="admin/login.html">Panel administracyjny</a>
+    <a href="admin/dashboard.html">Panel administracyjny</a>
   </footer>
 
   <script src="./js/kuchnia.js"></script>

--- a/docs/lazienka.html
+++ b/docs/lazienka.html
@@ -29,7 +29,7 @@
 
   <footer class="footer">
     <p>&copy; <span id="year"></span> Vikimeble</p>
-    <a href="admin/login.html">Panel administracyjny</a>
+    <a href="admin/dashboard.html">Panel administracyjny</a>
   </footer>
 
   <script src="./js/lazienka.js"></script>

--- a/docs/salon.html
+++ b/docs/salon.html
@@ -29,7 +29,7 @@
 
   <footer class="footer">
     <p>&copy; <span id="year"></span> Vikimeble</p>
-    <a href="admin/login.html">Panel administracyjny</a>
+    <a href="admin/dashboard.html">Panel administracyjny</a>
   </footer>
 
   <script src="./js/salon.js"></script>


### PR DESCRIPTION
## Summary
- Replace obsolete admin login page with automatic redirect to dashboard
- Update site pages to point admin link to `admin/dashboard.html` instead of `admin/login.html`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4390e31b48324888399a10b6e81c0