### PR TITLE
feat: support image categories

### DIFF
--- a/docs/admin/dashboard.html
+++ b/docs/admin/dashboard.html
@@ -19,6 +19,13 @@
     <section id="gallery-list"></section>
 
     <form id="upload-form" enctype="multipart/form-data">
+      <select name="category">
+        <option value="kuchnia">kuchnia</option>
+        <option value="salon">salon</option>
+        <option value="sypialnia">sypialnia</option>
+        <option value="lazienka">lazienka</option>
+        <option value="inne">inne</option>
+      </select>
       <input type="file" name="image" accept="image/*" required />
       <button type="submit">Dodaj zdjęcie</button>
     </form>

--- a/docs/admin/dashboard.js
+++ b/docs/admin/dashboard.js
@@ -27,6 +27,7 @@ function loadGallery() {
 form.addEventListener('submit', e => {
   e.preventDefault();
   const data = new FormData(form);
+  data.append('category', form.category.value);
   fetch('/api/upload', { method: 'POST', body: data })
     .then(() => {
       form.reset();

--- a/server/gallery.json
+++ b/server/gallery.json
@@ -1,1 +1,7 @@
-[]
+[
+  {
+    "id": 1,
+    "filename": "example.jpg",
+    "category": "kuchnia"
+  }
+]

--- a/server/server.js
+++ b/server/server.js
@@ -46,7 +46,11 @@ app.post('/api/login', (req, res) => {
 
 app.post('/api/upload', ensureAuth, upload.single('image'), (req, res) => {
   const images = JSON.parse(fs.readFileSync(galleryFile));
-  const img = { id: Date.now(), filename: req.file.filename };
+  const img = {
+    id: Date.now(),
+    filename: req.file.filename,
+    category: req.body.category
+  };
   images.push(img);
   fs.writeFileSync(galleryFile, JSON.stringify(images, null, 2));
   res.json(img);


### PR DESCRIPTION
## Summary
- allow selecting category when uploading gallery images
- include selected category in upload requests and persist in gallery.json

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c43dadcfcc8324833060973c0fb2ec