### PR TITLE
Support multiple image uploads

### DIFF
--- a/docs/admin/dashboard.html
+++ b/docs/admin/dashboard.html
@@ -26,7 +26,7 @@
         <option value="lazienka">lazienka</option>
         <option value="inne">inne</option>
       </select>
-      <input type="file" name="image" accept="image/*" required />
+      <input type="file" name="images" accept="image/*" multiple required />
       <button type="submit">Dodaj zdjęcie</button>
     </form>
   </main>

--- a/docs/admin/dashboard.js
+++ b/docs/admin/dashboard.js
@@ -107,8 +107,12 @@ function renderGallery() {
 
 form.addEventListener('submit', e => {
   e.preventDefault();
-  const data = new FormData(form);
+  const formData = new FormData(form);
+  const data = new FormData();
   data.append('category', form.category.value);
+  for (const file of formData.getAll('images')) {
+    data.append('images', file);
+  }
   fetch('/api/upload', { method: 'POST', body: data })
     .then(() => {
       form.reset();

--- a/server/server.js
+++ b/server/server.js
@@ -59,16 +59,19 @@ app.post('/api/login', (req, res) => {
   }
 });
 
-app.post('/api/upload', ensureAuth, upload.single('image'), (req, res) => {
+app.post('/api/upload', ensureAuth, upload.array('images'), (req, res) => {
   const images = JSON.parse(fs.readFileSync(galleryFile));
-  const img = {
-    id: Date.now(),
-    filename: req.file.filename,
-    category: req.body.category
-  };
-  images.push(img);
+  const uploaded = req.files.map((file, idx) => {
+    const img = {
+      id: Date.now() + idx,
+      filename: file.filename,
+      category: req.body.category
+    };
+    images.push(img);
+    return img;
+  });
   fs.writeFileSync(galleryFile, JSON.stringify(images, null, 2));
-  res.json(img);
+  res.json(uploaded);
 });
 
 app.delete('/api/gallery/:id', ensureAuth, (req, res) => {


### PR DESCRIPTION
## Summary
- Allow uploading multiple images to the gallery at once
- Enable multi-file selection in the admin dashboard
- Send all selected files via FormData to the server

## Testing
- `npm test`
- `curl -b /tmp/cookies.txt -F "category=kuchnia" -F "images=@/tmp/test1.png" -F "images=@/tmp/test2.png" http://localhost:3000/api/upload`
- `ls docs/images`
- `cat server/gallery.json`


------
https://chatgpt.com/codex/tasks/task_e_68c454b581c08324a3467e88246b8c27