### PR TITLE
Add dropdown navigation with mobile support

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -67,6 +67,44 @@ body {
   text-decoration: none;
 }
 
+/* Dropdown */
+.dropdown {
+  position: relative;
+}
+
+.submenu {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: rgba(0,0,0,0.8);
+  list-style: none;
+  margin: 0;
+  padding: 0.5rem 0;
+  z-index: 1000;
+}
+
+.submenu li {
+  margin: 0;
+}
+
+.submenu a {
+  display: block;
+  padding: 0.5rem 1rem;
+  color: var(--light);
+}
+
+.dropdown:hover .submenu,
+.dropdown.open .submenu {
+  display: block;
+}
+
+@media (max-width: 768px) {
+  .submenu {
+    position: static;
+  }
+}
+
 .phone {
   font-weight: 600;
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,12 +11,23 @@
   <header class="hero">
     <nav class="nav">
       <h1 class="logo"><a href="index.html"><img src="./images/logo.png" alt="Vikimeble logo" /></a></h1>
-<ul>
+      <ul>
         <li><a href="#gallery">Galeria</a></li>
+        <li class="dropdown">
+          <a href="#">Oferta</a>
+          <ul class="submenu">
+            <li><a href="kuchnia.html">Kuchnia</a></li>
+            <li><a href="salon.html">Salon</a></li>
+            <li><a href="sypialnia.html">Sypialnia</a></li>
+            <li><a href="lazienka.html">Łazienka</a></li>
+            <li><a href="inne.html">Inne</a></li>
+          </ul>
+        </li>
         <li><a href="#contact">Kontakt</a></li>
         <li><a href="#about">O nas</a></li>
         <li><a href="tel:787138178" class="phone">787 138 178</a></li>
-      </ul>    </nav>
+      </ul>
+    </nav>
     <div class="hero-content">
       <h2>Tworzymy meble, które kochasz</h2>
       <p>Designerskie projekty z naturalnego drewna prosto z naszej pracowni.</p>
@@ -98,6 +109,7 @@
     <a href="admin/dashboard.html">Panel administracyjny</a>
   </footer>
 
+  <script src="./js/menu.js"></script>
   <script src="./js/main.js"></script>
 </body>
 </html>

--- a/docs/inne.html
+++ b/docs/inne.html
@@ -13,6 +13,16 @@
       <h1 class="logo"><a href="index.html"><img src="./images/logo.png" alt="Vikimeble logo" /></a></h1>
       <ul>
         <li><a href="index.html#gallery">Galeria</a></li>
+        <li class="dropdown">
+          <a href="#">Oferta</a>
+          <ul class="submenu">
+            <li><a href="kuchnia.html">Kuchnia</a></li>
+            <li><a href="salon.html">Salon</a></li>
+            <li><a href="sypialnia.html">Sypialnia</a></li>
+            <li><a href="lazienka.html">Łazienka</a></li>
+            <li><a href="inne.html">Inne</a></li>
+          </ul>
+        </li>
         <li><a href="index.html#contact">Kontakt</a></li>
         <li><a href="index.html#about">O nas</a></li>
         <li><a href="tel:787138178" class="phone">787 138 178</a></li>
@@ -33,6 +43,7 @@
     <p>&copy; <span id="year"></span> Vikimeble</p>
     <a href="admin/dashboard.html">Panel administracyjny</a>
   </footer>
+  <script src="./js/menu.js"></script>
   <script src="./js/inne.js"></script>
 </body>
 </html>

--- a/docs/js/menu.js
+++ b/docs/js/menu.js
@@ -1,0 +1,11 @@
+// Dropdown menu toggle for mobile
+if (typeof document !== 'undefined') {
+  document.querySelectorAll('.dropdown > a').forEach(btn => {
+    btn.addEventListener('click', e => {
+      if (window.innerWidth <= 768) {
+        e.preventDefault();
+        btn.parentElement.classList.toggle('open');
+      }
+    });
+  });
+}

--- a/docs/kuchnia.html
+++ b/docs/kuchnia.html
@@ -13,6 +13,16 @@
       <h1 class="logo"><a href="index.html"><img src="./images/logo.png" alt="Vikimeble logo" /></a></h1>
       <ul>
         <li><a href="index.html#gallery">Galeria</a></li>
+        <li class="dropdown">
+          <a href="#">Oferta</a>
+          <ul class="submenu">
+            <li><a href="kuchnia.html">Kuchnia</a></li>
+            <li><a href="salon.html">Salon</a></li>
+            <li><a href="sypialnia.html">Sypialnia</a></li>
+            <li><a href="lazienka.html">Łazienka</a></li>
+            <li><a href="inne.html">Inne</a></li>
+          </ul>
+        </li>
         <li><a href="index.html#contact">Kontakt</a></li>
         <li><a href="index.html#about">O nas</a></li>
         <li><a href="tel:787138178" class="phone">787 138 178</a></li>
@@ -32,6 +42,7 @@
     <a href="admin/dashboard.html">Panel administracyjny</a>
   </footer>
 
+  <script src="./js/menu.js"></script>
   <script src="./js/kuchnia.js"></script>
 </body>
 </html>

--- a/docs/lazienka.html
+++ b/docs/lazienka.html
@@ -13,6 +13,16 @@
       <h1 class="logo"><a href="index.html"><img src="./images/logo.png" alt="Vikimeble logo" /></a></h1>
       <ul>
         <li><a href="index.html#gallery">Galeria</a></li>
+        <li class="dropdown">
+          <a href="#">Oferta</a>
+          <ul class="submenu">
+            <li><a href="kuchnia.html">Kuchnia</a></li>
+            <li><a href="salon.html">Salon</a></li>
+            <li><a href="sypialnia.html">Sypialnia</a></li>
+            <li><a href="lazienka.html">Łazienka</a></li>
+            <li><a href="inne.html">Inne</a></li>
+          </ul>
+        </li>
         <li><a href="index.html#contact">Kontakt</a></li>
         <li><a href="index.html#about">O nas</a></li>
         <li><a href="tel:787138178" class="phone">787 138 178</a></li>
@@ -32,6 +42,7 @@
     <a href="admin/dashboard.html">Panel administracyjny</a>
   </footer>
 
+  <script src="./js/menu.js"></script>
   <script src="./js/lazienka.js"></script>
 </body>
 </html>

--- a/docs/salon.html
+++ b/docs/salon.html
@@ -13,6 +13,16 @@
       <h1 class="logo"><a href="index.html"><img src="./images/logo.png" alt="Vikimeble logo" /></a></h1>
       <ul>
         <li><a href="index.html#gallery">Galeria</a></li>
+        <li class="dropdown">
+          <a href="#">Oferta</a>
+          <ul class="submenu">
+            <li><a href="kuchnia.html">Kuchnia</a></li>
+            <li><a href="salon.html">Salon</a></li>
+            <li><a href="sypialnia.html">Sypialnia</a></li>
+            <li><a href="lazienka.html">Łazienka</a></li>
+            <li><a href="inne.html">Inne</a></li>
+          </ul>
+        </li>
         <li><a href="index.html#contact">Kontakt</a></li>
         <li><a href="index.html#about">O nas</a></li>
         <li><a href="tel:787138178" class="phone">787 138 178</a></li>
@@ -32,6 +42,7 @@
     <a href="admin/dashboard.html">Panel administracyjny</a>
   </footer>
 
+  <script src="./js/menu.js"></script>
   <script src="./js/salon.js"></script>
 </body>
 </html>

--- a/docs/sypialnia.html
+++ b/docs/sypialnia.html
@@ -13,6 +13,16 @@
       <h1 class="logo"><a href="index.html"><img src="./images/logo.png" alt="Vikimeble logo" /></a></h1>
       <ul>
         <li><a href="index.html#gallery">Galeria</a></li>
+        <li class="dropdown">
+          <a href="#">Oferta</a>
+          <ul class="submenu">
+            <li><a href="kuchnia.html">Kuchnia</a></li>
+            <li><a href="salon.html">Salon</a></li>
+            <li><a href="sypialnia.html">Sypialnia</a></li>
+            <li><a href="lazienka.html">Łazienka</a></li>
+            <li><a href="inne.html">Inne</a></li>
+          </ul>
+        </li>
         <li><a href="index.html#contact">Kontakt</a></li>
         <li><a href="index.html#about">O nas</a></li>
         <li><a href="tel:787138178" class="phone">787 138 178</a></li>
@@ -32,6 +42,7 @@
     <a href="admin/dashboard.html">Panel administracyjny</a>
   </footer>
 
+  <script src="./js/menu.js"></script>
   <script src="./js/sypialnia.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add "Oferta" dropdown menu linking to category pages on all site pages
- Style dropdown and submenu for desktop and mobile
- Include JavaScript to toggle dropdown on small screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c454c4a4c483248daf6a6db8257877