### PR TITLE
Map gallery API responses to include image paths and alt text

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -38,7 +38,14 @@ app.get('/api/gallery', (req, res) => {
       images = images.filter(img => img.category === category);
     }
 
-    res.json(images);
+    const mapped = images.map(img => {
+      const mappedImg = { src: '/images/' + img.filename };
+      if (img.alt) mappedImg.alt = img.alt;
+      else if (img.category) mappedImg.alt = img.category;
+      return mappedImg;
+    });
+
+    res.json(mapped);
   });
 });
 


### PR DESCRIPTION
## Summary
- Transform `/api/gallery` responses so each item includes a `src` path and optional `alt` text derived from metadata.
- Ensure gallery images under `docs/images` are served via Express static middleware.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c45709795483248b8246c92ec6f9e8