### PR TITLE
refactor: use image fields directly in galleries

### DIFF
--- a/docs/js/inne.js
+++ b/docs/js/inne.js
@@ -4,12 +4,12 @@ async function loadGallery() {
   try {
     const res = await fetch('/api/gallery?category=inne');
     const images = await res.json();
-    images.forEach(({ src, alt }) => {
+    images.forEach(image => {
       const fig = document.createElement('figure');
       fig.className = 'item';
       const img = document.createElement('img');
-      img.src = src;
-      img.alt = alt;
+      img.src = image.src;
+      img.alt = image.alt || '';
       fig.appendChild(img);
       grid.appendChild(fig);
     });

--- a/docs/js/kuchnia.js
+++ b/docs/js/kuchnia.js
@@ -4,12 +4,12 @@ async function loadGallery() {
   try {
     const res = await fetch('/api/gallery?category=kuchnia');
     const images = await res.json();
-    images.forEach(({ src, alt }) => {
+    images.forEach(image => {
       const fig = document.createElement('figure');
       fig.className = 'item';
       const img = document.createElement('img');
-      img.src = src;
-      img.alt = alt;
+      img.src = image.src;
+      img.alt = image.alt || '';
       fig.appendChild(img);
       grid.appendChild(fig);
     });

--- a/docs/js/lazienka.js
+++ b/docs/js/lazienka.js
@@ -4,12 +4,12 @@ async function loadGallery() {
   try {
     const res = await fetch('/api/gallery?category=lazienka');
     const images = await res.json();
-    images.forEach(({ src, alt }) => {
+    images.forEach(image => {
       const fig = document.createElement('figure');
       fig.className = 'item';
       const img = document.createElement('img');
-      img.src = src;
-      img.alt = alt;
+      img.src = image.src;
+      img.alt = image.alt || '';
       fig.appendChild(img);
       grid.appendChild(fig);
     });

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -3,12 +3,12 @@
 function renderPreview(sectionId, images, link) {
   const container = document.getElementById(sectionId);
   if (!container) return;
-  images.forEach(({ src, alt }) => {
+  images.forEach(image => {
     const a = document.createElement('a');
     a.href = link;
     const img = document.createElement('img');
-    img.src = src;
-    img.alt = alt;
+    img.src = image.src;
+    img.alt = image.alt || '';
     a.appendChild(img);
     container.appendChild(a);
   });

--- a/docs/js/salon.js
+++ b/docs/js/salon.js
@@ -4,12 +4,12 @@ async function loadGallery() {
   try {
     const res = await fetch('/api/gallery?category=salon');
     const images = await res.json();
-    images.forEach(({ src, alt }) => {
+    images.forEach(image => {
       const fig = document.createElement('figure');
       fig.className = 'item';
       const img = document.createElement('img');
-      img.src = src;
-      img.alt = alt;
+      img.src = image.src;
+      img.alt = image.alt || '';
       fig.appendChild(img);
       grid.appendChild(fig);
     });

--- a/docs/js/sypialnia.js
+++ b/docs/js/sypialnia.js
@@ -4,12 +4,12 @@ async function loadGallery() {
   try {
     const res = await fetch('/api/gallery?category=sypialnia');
     const images = await res.json();
-    images.forEach(({ src, alt }) => {
+    images.forEach(image => {
       const fig = document.createElement('figure');
       fig.className = 'item';
       const img = document.createElement('img');
-      img.src = src;
-      img.alt = alt;
+      img.src = image.src;
+      img.alt = image.alt || '';
       fig.appendChild(img);
       grid.appendChild(fig);
     });


### PR DESCRIPTION
## Summary
- avoid destructuring in preview and gallery scripts
- assign image.src and image.alt directly when rendering

## Testing
- `npm test`
- `node <verification script>`

------
https://chatgpt.com/codex/tasks/task_e_68c4579be61083248f847a803ee34dc3