### PR TITLE
feat(admin): add login form

### DIFF
--- a/docs/admin/login.html
+++ b/docs/admin/login.html
@@ -2,14 +2,34 @@
 <html lang="pl">
 <head>
   <meta charset="UTF-8" />
-  <meta http-equiv="refresh" content="0; url=dashboard.html" />
-  <title>Przekierowanie</title>
+  <title>Logowanie</title>
   <link rel="stylesheet" href="../css/styles.css" />
 </head>
 <body>
-  <p>Trwa przekierowywanie do panelu administracyjnego...</p>
+  <form id="login-form">
+    <label>
+      Hasło:
+      <input type="password" name="password" />
+    </label>
+    <button type="submit">Zaloguj</button>
+  </form>
   <script>
-    window.location.href = 'dashboard.html';
+    document
+      .getElementById('login-form')
+      .addEventListener('submit', async function (e) {
+        e.preventDefault();
+        const formData = new FormData(e.target);
+        const res = await fetch('/api/login', {
+          method: 'POST',
+          body: formData,
+          credentials: 'same-origin',
+        });
+        if (res.ok) {
+          window.location.href = 'dashboard.html';
+        } else {
+          alert('Nieprawidłowe hasło');
+        }
+      });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace automatic redirect with manual admin login form
- post password to `/api/login` and redirect to dashboard on success

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c468548d30832482a3cb9cd969da6c