### PR TITLE
Protect admin static assets

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -16,8 +16,17 @@ app.use(session({
 
 const publicDir = path.join(__dirname, '../docs');
 const adminDir = path.join(__dirname, '../docs/admin');
+
+// Unprotected login page route
+app.get('/admin/login.html', (req, res) => {
+  res.sendFile(path.join(adminDir, 'login.html'));
+});
+
+// Protect admin assets
+app.use('/admin', ensureAuth, express.static(adminDir));
+
+// Serve public assets
 app.use(express.static(publicDir));
-app.use('/admin', express.static(adminDir));
 
 const galleryFile = path.join(__dirname, 'gallery.json');
 const categoriesFile = path.join(__dirname, 'categories.json');


### PR DESCRIPTION
## Summary
- secure admin static files with `ensureAuth`
- expose `/admin/login.html` without auth

## Testing
- `npm test`
- `curl -i http://localhost:3000/admin/dashboard.html`
- `curl -i http://localhost:3000/admin/login.html`


------
https://chatgpt.com/codex/tasks/task_e_68c4686fd1148324812d37e61c81d74f