### PR TITLE
Add full gallery mode and update admin dashboard

### DIFF
--- a/docs/admin/dashboard.js
+++ b/docs/admin/dashboard.js
@@ -46,10 +46,10 @@ function refreshPreviews() {
 }
 
 function loadGallery() {
-  fetch('/api/gallery')
+  fetch('/api/gallery?mode=full')
     .then(res => res.json())
     .then(images => {
-galleryData = images;
+      galleryData = images;
       updateFilterOptions();
       renderGallery();
     });
@@ -88,7 +88,8 @@ function renderGallery() {
     groups[cat].forEach(img => {
       const wrapper = document.createElement('div');
       const image = document.createElement('img');
-      image.src = `../images/${img.filename}`;
+      const src = img.src || `../images/${img.filename}`;
+      image.src = src;
       image.width = 150;
       const btn = document.createElement('button');
       btn.textContent = 'Usuń';

--- a/server/server.js
+++ b/server/server.js
@@ -46,9 +46,20 @@ app.get('/api/gallery', (req, res) => {
     if (err) return res.status(500).send('Błąd odczytu');
     let images = JSON.parse(data);
 
-    const { category } = req.query;
+    const { category, mode } = req.query;
     if (category) {
       images = images.filter(img => img.category === category);
+    }
+
+    // Return original objects when mode=full, otherwise map to public fields
+    if (mode === 'full') {
+      const full = images.map(img => ({
+        id: img.id,
+        filename: img.filename,
+        category: img.category,
+        alt: img.alt || img.category
+      }));
+      return res.json(full);
     }
 
     const mapped = images.map(img => {


### PR DESCRIPTION
## Summary
- add optional `mode=full` query for `/api/gallery` to expose id, filename, category and alt
- update admin dashboard to consume API fields and refresh properly

## Testing
- `curl -s http://localhost:3000/api/gallery?mode=full; echo`
- `curl -s -b cookie.txt -F 'category=test' -F 'images=@web-site-jedziniak/docs/images/logo.png' http://localhost:3000/api/upload; echo`
- `curl -s http://localhost:3000/api/gallery?mode=full; echo`
- `curl -s -b cookie.txt -X DELETE http://localhost:3000/api/gallery/1757705526597; echo`
- `curl -s http://localhost:3000/api/gallery?mode=full; echo`


------
https://chatgpt.com/codex/tasks/task_e_68c47461b35c8324b407f552cc75c177