### PR TITLE
Limit home gallery preview

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -184,11 +184,12 @@ body {
   display: flex;
   overflow-x: auto;
   gap: 1rem;
+  justify-content: center;
 }
 
 .scroll-gallery img {
-  width: 250px;
-  height: 160px;
+  width: 300px;
+  height: 200px;
   object-fit: cover;
 }
 

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -3,7 +3,7 @@
 function renderPreview(sectionId, images, link) {
   const container = document.getElementById(sectionId);
   if (!container) return;
-  images.forEach(image => {
+  images.slice(0, 4).forEach(image => {
     const a = document.createElement('a');
     a.href = link;
     const img = document.createElement('img');


### PR DESCRIPTION
## Summary
- Show only the first four images in home page preview
- Center and enlarge home page preview thumbnails

## Testing
- `node - <<'NODE'` (rendered images: 4)
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c47663b4bc83248b92acb4f2dffc85