### PR TITLE
Add responsive gallery grid to section pages

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -217,6 +217,26 @@ body {
   transform: scale(1.1);
 }
 
+#gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+#gallery-grid .item {
+  position: relative;
+  overflow: hidden;
+}
+#gallery-grid img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transition: transform 0.5s ease;
+  display: block;
+}
+#gallery-grid .item:hover img {
+  transform: scale(1.1);
+}
+
 /* Opinie */
 .testimonials h3 {
   text-align: center;

--- a/docs/inne.html
+++ b/docs/inne.html
@@ -32,6 +32,7 @@
       <h2>Inne</h2>
     </div>
   </header>
+  <div id="gallery-grid" class="gallery grid"></div>
   <main>
     <section class="section">
       <div class="container">

--- a/docs/kuchnia.html
+++ b/docs/kuchnia.html
@@ -35,7 +35,7 @@
     </div>
   </header>
 
-  <div id="gallery-grid"></div>
+  <div id="gallery-grid" class="gallery grid"></div>
 
   <footer class="footer">
     <p>&copy; <span id="year"></span> Vikimeble</p>

--- a/docs/lazienka.html
+++ b/docs/lazienka.html
@@ -35,7 +35,7 @@
     </div>
   </header>
 
-  <div id="gallery-grid"></div>
+  <div id="gallery-grid" class="gallery grid"></div>
 
   <footer class="footer">
     <p>&copy; <span id="year"></span> Vikimeble</p>

--- a/docs/salon.html
+++ b/docs/salon.html
@@ -35,7 +35,7 @@
     </div>
   </header>
 
-  <div id="gallery-grid"></div>
+  <div id="gallery-grid" class="gallery grid"></div>
 
   <footer class="footer">
     <p>&copy; <span id="year"></span> Vikimeble</p>

--- a/docs/sypialnia.html
+++ b/docs/sypialnia.html
@@ -35,7 +35,7 @@
     </div>
   </header>
 
-  <div id="gallery-grid"></div>
+  <div id="gallery-grid" class="gallery grid"></div>
 
   <footer class="footer">
     <p>&copy; <span id="year"></span> Vikimeble</p>


### PR DESCRIPTION
## Summary
- Add `gallery grid` classes to gallery containers on kitchen, living room, bedroom, bathroom and other pages
- Introduce `#gallery-grid` CSS with smaller thumbnails for responsive layout
- Insert gallery container on misc page so JS can populate images

## Testing
- `npm test`
- `npm start` then `curl -I http://localhost:3000/kuchnia.html`


------
https://chatgpt.com/codex/tasks/task_e_68c476712d448324ad7d8aa637cec865