### PR TITLE
feat: add preview and async gallery update in admin panel

### DIFF
--- a/docs/admin/dashboard.html
+++ b/docs/admin/dashboard.html
@@ -28,6 +28,8 @@
         <option value="inne">inne</option>
       </select>
       <input type="file" name="images" accept="image/*" multiple required />
+      <p class="form-hint">Możesz zaznaczyć kilka plików naraz</p>
+      <div id="preview"></div>
       <button type="submit">Dodaj zdjęcie</button>
     </form>
   </main>

--- a/docs/admin/dashboard.js
+++ b/docs/admin/dashboard.js
@@ -1,5 +1,7 @@
 const list = document.getElementById('gallery-list');
 const form = document.getElementById('upload-form');
+const fileInput = form.querySelector('input[type="file"]');
+const preview = document.getElementById('preview');
 
 // Dynamiczny filtr kategorii
 const filter = document.createElement('select');
@@ -12,6 +14,20 @@ list.parentNode.insertBefore(filter, list);
 let galleryData = [];
 
 filter.addEventListener('change', renderGallery);
+
+fileInput.addEventListener('change', () => {
+  preview.innerHTML = '';
+  for (const file of fileInput.files) {
+    const reader = new FileReader();
+    reader.onload = e => {
+      const img = document.createElement('img');
+      img.src = e.target.result;
+      img.width = 100;
+      preview.appendChild(img);
+    };
+    reader.readAsDataURL(file);
+  }
+});
 
 
 // Kopia funkcji renderPreview z głównego skryptu, aby można było
@@ -117,6 +133,7 @@ form.addEventListener('submit', e => {
   fetch('/api/upload', { method: 'POST', body: data })
     .then(() => {
       form.reset();
+      preview.innerHTML = '';
       loadGallery();
       refreshPreviews();
 

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -314,3 +314,14 @@ body {
     font-size: 2rem;
   }
 }
+
+#preview {
+  display: flex;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+#preview img {
+  width: 100px;
+  height: auto;
+}


### PR DESCRIPTION
## Summary
- show hint about multi-file selection
- add client-side thumbnail preview before upload
- refresh gallery list in place after upload

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c47970b9cc83249736c6bad62fb0dd