### PR TITLE
fix login form submission

### DIFF
--- a/docs/admin/login.html
+++ b/docs/admin/login.html
@@ -17,10 +17,10 @@
       .getElementById('login-form')
       .addEventListener('submit', async function (e) {
         e.preventDefault();
-        const formData = new FormData(e.target);
+        const body = new URLSearchParams(new FormData(e.target));
         const res = await fetch('/api/login', {
           method: 'POST',
-          body: formData,
+          body,
           credentials: 'same-origin',
         });
         if (res.ok) {


### PR DESCRIPTION
## Summary
- use URLSearchParams for admin login form so express receives password

## Testing
- `npm test`
- `npm start` (manually tested login; hit ctrl+c to stop)
- `curl -i -d 'password=admin' http://localhost:3000/api/login`


------
https://chatgpt.com/codex/tasks/task_e_68c47ae166a08324afd8ce55a96e5763