### PR TITLE
Refresh categories after image uploads

### DIFF
--- a/docs/admin/dashboard.js
+++ b/docs/admin/dashboard.js
@@ -115,11 +115,11 @@ form.addEventListener('submit', e => {
     data.append('images', file);
   }
   fetch('/api/upload', { method: 'POST', body: data })
+    .then(() => fetch('/api/refresh-categories'))
     .then(() => {
       form.reset();
       loadGallery();
       refreshPreviews();
-
     });
 });
 


### PR DESCRIPTION
## Summary
- Rebuild categories.json from gallery data and expose `/api/refresh-categories` endpoint
- Update upload handler to regenerate category previews automatically
- Trigger category refresh from dashboard after image uploads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c4799d43488324911db723e8686b6d