### PR TITLE
Include credentials with upload requests and clear file input

### DIFF
--- a/docs/admin/dashboard.js
+++ b/docs/admin/dashboard.js
@@ -133,11 +133,12 @@ form.addEventListener('submit', e => {
   for (const file of formData.getAll('images')) {
     data.append('images', file);
   }
-  fetch('/api/upload', { method: 'POST', body: data })
+  fetch('/api/upload', { method: 'POST', body: data, credentials: 'include' })
     .then(() => fetch('/api/refresh-categories'))
     .then(() => {
       form.reset();
       preview.innerHTML = '';
+      fileInput.value = '';
       loadGallery();
       refreshPreviews();
     });


### PR DESCRIPTION
## Summary
- send cookies with upload requests by adding `credentials: 'include'`
- reset file input after uploads before refreshing gallery

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c48ce9250883249ba36948310e39ac