### PR TITLE
Enable horizontal scrolling gallery in admin dashboard

### DIFF
--- a/docs/admin/dashboard.js
+++ b/docs/admin/dashboard.js
@@ -101,6 +101,7 @@ function renderGallery() {
     section.appendChild(heading);
 
     const container = document.createElement('div');
+    container.classList.add('scroll-gallery', 'admin-gallery');
     groups[cat].forEach(img => {
       const wrapper = document.createElement('div');
       const image = document.createElement('img');

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -323,3 +323,21 @@ body {
   width: 100px;
   height: auto;
 }
+
+.scroll-gallery {
+  display: flex;
+  gap: 1rem;
+  overflow-x: auto;
+}
+
+.admin-gallery > div {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.admin-gallery img {
+  width: 150px;
+  height: 100px;
+  object-fit: cover;
+}


### PR DESCRIPTION
## Summary
- Enable scrollable admin gallery by applying `scroll-gallery` and `admin-gallery` classes in dashboard renderer.
- Add CSS for horizontal gallery layout with constrained image thumbnails and column-aligned delete buttons.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c492de959c832483b6da5493e5a816