### PR TITLE
Add mobile navigation toggle

### DIFF
--- a/docs/admin/dashboard.html
+++ b/docs/admin/dashboard.html
@@ -10,6 +10,7 @@
 <body>
   <nav class="nav">
     <h1 class="logo"><a href="../index.html"><img src="../images/logo.png" alt="Vikimeble logo" /></a></h1>
+    <button class="menu-toggle" aria-label="Menu"></button>
     <a href="../index.html#gallery" class="btn">Galeria</a>
     <a href="../index.html#contact" class="btn nav-cta">Kontakt</a>
     <a href="/api/logout" class="btn">Wyloguj</a>
@@ -34,6 +35,7 @@
     </form>
   </main>
 
+  <script src="../js/menu.js"></script>
   <script src="dashboard.js"></script>
 </body>
 </html>

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -67,6 +67,18 @@ body {
   text-decoration: none;
 }
 
+.menu-toggle {
+  display: none;
+  background: none;
+  border: none;
+  color: var(--light);
+  font-size: 2rem;
+  cursor: pointer;
+}
+.menu-toggle::before {
+  content: "☰";
+}
+
 /* Dropdown */
 .dropdown {
   position: relative;
@@ -102,6 +114,16 @@ body {
 @media (max-width: 768px) {
   .submenu {
     position: static;
+  }
+  .nav > ul {
+    display: none;
+  }
+  .menu-toggle {
+    display: block;
+  }
+  .nav.open > ul {
+    display: flex;
+    flex-direction: column;
   }
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,6 +11,7 @@
   <header class="hero">
     <nav class="nav">
       <h1 class="logo"><a href="index.html"><img src="./images/logo.png" alt="Vikimeble logo" /></a></h1>
+      <button class="menu-toggle" aria-label="Menu"></button>
       <ul>
         <li><a href="#gallery">Galeria</a></li>
         <li class="dropdown">

--- a/docs/inne.html
+++ b/docs/inne.html
@@ -11,6 +11,7 @@
   <header class="hero">
     <nav class="nav">
       <h1 class="logo"><a href="index.html"><img src="./images/logo.png" alt="Vikimeble logo" /></a></h1>
+      <button class="menu-toggle" aria-label="Menu"></button>
       <ul>
         <li><a href="index.html#gallery">Galeria</a></li>
         <li class="dropdown">

--- a/docs/js/menu.js
+++ b/docs/js/menu.js
@@ -1,5 +1,14 @@
 // Dropdown menu toggle for mobile
 if (typeof document !== 'undefined') {
+  const nav = document.querySelector('.nav');
+  const toggle = document.querySelector('.menu-toggle');
+
+  if (toggle && nav) {
+    toggle.addEventListener('click', () => {
+      nav.classList.toggle('open');
+    });
+  }
+
   document.querySelectorAll('.dropdown > a').forEach(btn => {
     btn.addEventListener('click', e => {
       if (window.innerWidth <= 768) {

--- a/docs/kuchnia.html
+++ b/docs/kuchnia.html
@@ -11,6 +11,7 @@
   <header class="hero">
         <nav class="nav">
       <h1 class="logo"><a href="index.html"><img src="./images/logo.png" alt="Vikimeble logo" /></a></h1>
+      <button class="menu-toggle" aria-label="Menu"></button>
       <ul>
         <li><a href="index.html#gallery">Galeria</a></li>
         <li class="dropdown">

--- a/docs/lazienka.html
+++ b/docs/lazienka.html
@@ -11,6 +11,7 @@
   <header class="hero">
         <nav class="nav">
       <h1 class="logo"><a href="index.html"><img src="./images/logo.png" alt="Vikimeble logo" /></a></h1>
+      <button class="menu-toggle" aria-label="Menu"></button>
       <ul>
         <li><a href="index.html#gallery">Galeria</a></li>
         <li class="dropdown">

--- a/docs/salon.html
+++ b/docs/salon.html
@@ -11,6 +11,7 @@
   <header class="hero">
         <nav class="nav">
       <h1 class="logo"><a href="index.html"><img src="./images/logo.png" alt="Vikimeble logo" /></a></h1>
+      <button class="menu-toggle" aria-label="Menu"></button>
       <ul>
         <li><a href="index.html#gallery">Galeria</a></li>
         <li class="dropdown">

--- a/docs/sypialnia.html
+++ b/docs/sypialnia.html
@@ -11,6 +11,7 @@
   <header class="hero">
         <nav class="nav">
       <h1 class="logo"><a href="index.html"><img src="./images/logo.png" alt="Vikimeble logo" /></a></h1>
+      <button class="menu-toggle" aria-label="Menu"></button>
       <ul>
         <li><a href="index.html#gallery">Galeria</a></li>
         <li class="dropdown">


### PR DESCRIPTION
## Summary
- add menu toggle button to site navbars
- hide main nav list on small screens and show a toggle button
- implement JavaScript to toggle navigation visibility while keeping submenu behavior
- display a visible hamburger icon for the mobile menu toggle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c49233c60483248f0f413362a03565