### PR TITLE
Add error logging and secure admin API routes

### DIFF
--- a/docs/admin/dashboard.js
+++ b/docs/admin/dashboard.js
@@ -118,9 +118,11 @@ function renderGallery() {
           if (res.ok) {
             loadGallery();
           } else {
-            alert('Nie udało się usunąć zdjęcia.');
+            console.error('Delete failed with status', res.status);
+            alert('Nie udało się usunąć zdjęcia. Status: ' + res.status);
           }
         } catch (err) {
+          console.error(err);
           alert('Wystąpił błąd podczas usuwania zdjęcia.');
         } finally {
           btn.disabled = false;
@@ -149,10 +151,12 @@ form.addEventListener('submit', async e => {
     }
     const uploadRes = await fetch('/api/upload', { method: 'POST', body: data, credentials: 'include' });
     if (!uploadRes.ok) {
+      console.error('Upload failed with status', uploadRes.status);
       throw new Error('Upload failed');
     }
     const refreshRes = await fetch('/api/refresh-categories');
     if (!refreshRes.ok) {
+      console.error('Refresh failed with status', refreshRes.status);
       throw new Error('Refresh failed');
     }
     form.reset();
@@ -161,6 +165,7 @@ form.addEventListener('submit', async e => {
     loadGallery();
     refreshPreviews();
   } catch (err) {
+    console.error(err);
     alert('Wystąpił błąd podczas przesyłania plików.');
   } finally {
     submitBtn.disabled = false;

--- a/server/server.js
+++ b/server/server.js
@@ -77,11 +77,12 @@ function refreshCategories() {
 }
 
 function ensureAuth(req, res, next) {
+  console.log(req.session);
   if (req.session && req.session.loggedIn) return next();
   res.redirect('/login');
 }
 
-app.get('/api/gallery', (req, res) => {
+app.get('/api/gallery', ensureAuth, (req, res) => {
   fs.readFile(galleryFile, (err, data) => {
     if (err) return res.status(500).send('Błąd odczytu');
     let images = JSON.parse(data);


### PR DESCRIPTION
## Summary
- log upload and delete errors on admin dashboard with status codes
- protect gallery endpoint with session-aware auth logging

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c49768834c8324954b8ffd12b362ce