### PR TITLE
feat: add slide-in mobile navigation

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -115,15 +115,25 @@ body {
   .submenu {
     position: static;
   }
+  .nav {
+    position: relative;
+    height: 60px;
+  }
   .nav > ul {
-    display: none;
+    position: fixed;
+    top: 0;
+    right: -100%;
+    height: 100vh;
+    width: 250px;
+    flex-direction: column;
+    background: rgba(0,0,0,0.8);
+    transition: right 0.3s ease;
   }
   .menu-toggle {
     display: block;
   }
   .nav.open > ul {
-    display: flex;
-    flex-direction: column;
+    right: 0;
   }
 }
 

--- a/docs/js/menu.js
+++ b/docs/js/menu.js
@@ -5,6 +5,7 @@ if (typeof document !== 'undefined') {
 
   if (toggle && nav) {
     toggle.addEventListener('click', () => {
+      // Show or hide the navigation by toggling the `.open` class
       nav.classList.toggle('open');
     });
   }


### PR DESCRIPTION
## Summary
- implement fixed slide-in menu for mobile viewport
- document nav toggle script for `.open` class

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c49f4208fc8324b1bf59e3c4837cb6