### PR TITLE
Allow public access to gallery API

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -82,12 +82,16 @@ function ensureAuth(req, res, next) {
   res.redirect('/login');
 }
 
-app.get('/api/gallery', ensureAuth, (req, res) => {
+app.get('/api/gallery', (req, res) => {
+  const { mode } = req.query;
+  if (mode === 'full' && !(req.session && req.session.loggedIn)) {
+    return res.redirect('/login');
+  }
   fs.readFile(galleryFile, (err, data) => {
     if (err) return res.status(500).send('Błąd odczytu');
     let images = JSON.parse(data);
 
-    const { category, mode } = req.query;
+    const { category } = req.query;
     if (category) {
       images = images.filter(img => img.category === category);
     }


### PR DESCRIPTION
## Summary
- Allow unauthenticated requests to `/api/gallery` and require login only when `mode=full`

## Testing
- `npm test`
- `curl -I http://localhost:3000/api/gallery?category=kuchnia`
- `curl -I http://localhost:3000/api/gallery?mode=full`
- `curl -L http://localhost:3000/index.html | head -n 20`
- `curl -L http://localhost:3000/kuchnia.html | head -n 20`
- `curl -I http://localhost:3000/images/logo.png`

------
https://chatgpt.com/codex/tasks/task_e_68c4a227b9e883249eebc1c87a40d71a