### PR TITLE
Fix repeated gallery deletes failing

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -37,6 +37,54 @@ const categoriesFile = path.join(__dirname, 'categories.json');
 const usersFile = path.join(__dirname, 'users.json');
 const upload = multer({ dest: path.join(publicDir, 'images') });
 
+function loadGalleryData() {
+  let images = [];
+  try {
+    images = JSON.parse(fs.readFileSync(galleryFile));
+  } catch (e) {
+    return [];
+  }
+
+  let changed = false;
+  let maxId = images.reduce((max, img) => {
+    const id = Number(img.id);
+    return Number.isFinite(id) && id > max ? id : max;
+  }, 0);
+
+  const normalised = images.map(img => {
+    const numericId = Number(img.id);
+    if (Number.isFinite(numericId)) {
+      if (numericId !== img.id) {
+        changed = true;
+        return { ...img, id: numericId };
+      }
+      return img;
+    }
+    changed = true;
+    const newId = ++maxId;
+    return { ...img, id: newId };
+  });
+
+  if (changed) {
+    fs.writeFileSync(galleryFile, JSON.stringify(normalised, null, 2));
+  }
+
+  return normalised;
+}
+
+function saveGalleryData(images) {
+  fs.writeFileSync(galleryFile, JSON.stringify(images, null, 2));
+}
+
+function nextGalleryId(images) {
+  return (
+    images.reduce((max, img) => {
+      const id = Number(img.id);
+      return Number.isFinite(id) && id > max ? id : max;
+    }, 0) + 1
+  );
+}
+
 function loadUsers() {
   try {
     return JSON.parse(fs.readFileSync(usersFile));
@@ -60,7 +108,7 @@ if (users.length === 0) {
 
 // Rebuilds categories.json using the first four images from each category
 function refreshCategories() {
-  const images = JSON.parse(fs.readFileSync(galleryFile));
+  const images = loadGalleryData();
   const categories = images.reduce((acc, img) => {
     const cat = img.category || 'inne';
     (acc[cat] = acc[cat] || []).push({
@@ -87,9 +135,8 @@ app.get('/api/gallery', (req, res) => {
   if (mode === 'full' && !(req.session && req.session.loggedIn)) {
     return res.redirect('/login');
   }
-  fs.readFile(galleryFile, (err, data) => {
-    if (err) return res.status(500).send('Błąd odczytu');
-    let images = JSON.parse(data);
+  try {
+    let images = loadGalleryData();
 
     const { category } = req.query;
     if (category) {
@@ -115,7 +162,9 @@ app.get('/api/gallery', (req, res) => {
     });
 
     res.json(mapped);
-  });
+  } catch (err) {
+    res.status(500).send('Błąd odczytu');
+  }
 });
 
 app.get('/api/categories', (req, res) => {
@@ -162,28 +211,29 @@ app.get('/api/logout', (req, res) => {
 });
 
 app.post('/api/upload', ensureAuth, upload.array('images'), (req, res) => {
-  const images = JSON.parse(fs.readFileSync(galleryFile));
+  const images = loadGalleryData();
+  let idCounter = nextGalleryId(images);
   const uploaded = req.files.map((file, idx) => {
     const img = {
-      id: Date.now() + idx,
+      id: idCounter + idx,
       filename: file.filename,
       category: req.body.category
     };
     images.push(img);
     return img;
   });
-  fs.writeFileSync(galleryFile, JSON.stringify(images, null, 2));
+  saveGalleryData(images);
   refreshCategories();
   res.json(uploaded);
 });
 
 app.delete('/api/gallery/:id', ensureAuth, (req, res) => {
-  const id = parseInt(req.params.id, 10);
-  const images = JSON.parse(fs.readFileSync(galleryFile));
+  const id = Number(req.params.id);
+  const images = loadGalleryData();
   const index = images.findIndex(i => i.id === id);
   if (index === -1) return res.status(404).end();
   const [img] = images.splice(index, 1);
-  fs.writeFileSync(galleryFile, JSON.stringify(images, null, 2));
+  saveGalleryData(images);
   try {
     fs.unlinkSync(path.join(publicDir, 'images', img.filename));
   } catch (e) {


### PR DESCRIPTION
## Summary
- normalize gallery IDs when loading data to guarantee numeric IDs
- reuse helper functions to load/save gallery JSON consistently
- assign incremental IDs to newly uploaded images so delete API always finds them

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5750e1b4083248b3cba042c03ab11