### PR TITLE
Handle admin auth failures during gallery actions

### DIFF
--- a/docs/admin/dashboard.js
+++ b/docs/admin/dashboard.js
@@ -15,6 +15,25 @@ let galleryData = [];
 
 filter.addEventListener('change', renderGallery);
 
+async function fetchOrRedirect(url, options = {}) {
+  const { silent, ...fetchOptions } = options;
+  const config = { ...fetchOptions, credentials: 'include' };
+  try {
+    const res = await fetch(url, config);
+    if (res.status === 401) {
+      window.location.href = '/login';
+      return null;
+    }
+    return res;
+  } catch (error) {
+    console.error('Błąd połączenia z serwerem', error);
+    if (!silent) {
+      alert('Wystąpił problem z połączeniem z serwerem.');
+    }
+    return null;
+  }
+}
+
 fileInput.addEventListener('change', () => {
   preview.innerHTML = '';
   for (const file of fileInput.files) {
@@ -50,25 +69,32 @@ function renderPreview(sectionId, images, link) {
 // Pobiera dane miniatur dla wszystkich kategorii i aktualizuje sekcje
 // na stronie. Funkcja może być uruchamiana po dodaniu obrazu lub
 // periodycznie w celu odświeżania widoku.
-function refreshPreviews() {
-  fetch('/api/categories')
-    .then(res => res.json())
-    .then(data => {
-      renderPreview('kuchnia-preview', data.kuchnia || [], 'kuchnia.html');
-      renderPreview('salon-preview', data.salon || [], 'salon.html');
-      renderPreview('lazienka-preview', data.lazienka || [], 'lazienka.html');
-      renderPreview('inne-preview', data.inne || [], 'inne.html');
-    });
+async function refreshPreviews() {
+  const res = await fetchOrRedirect('/api/categories', { silent: true });
+  if (!res) return;
+  try {
+    const data = await res.json();
+    renderPreview('kuchnia-preview', data.kuchnia || [], 'kuchnia.html');
+    renderPreview('salon-preview', data.salon || [], 'salon.html');
+    renderPreview('lazienka-preview', data.lazienka || [], 'lazienka.html');
+    renderPreview('inne-preview', data.inne || [], 'inne.html');
+  } catch (error) {
+    console.error('Nie udało się odczytać danych kategorii', error);
+  }
 }
 
-function loadGallery() {
-  fetch('/api/gallery?mode=full')
-    .then(res => res.json())
-    .then(images => {
-      galleryData = images;
-      updateFilterOptions();
-      renderGallery();
-    });
+async function loadGallery() {
+  const res = await fetchOrRedirect('/api/gallery?mode=full');
+  if (!res) return;
+  try {
+    const images = await res.json();
+    galleryData = images;
+    updateFilterOptions();
+    renderGallery();
+  } catch (error) {
+    console.error('Nie udało się odczytać danych galerii', error);
+    alert('Wystąpił błąd podczas ładowania galerii.');
+  }
 }
 
 function updateFilterOptions() {
@@ -114,7 +140,8 @@ function renderGallery() {
       btn.onclick = async () => {
         btn.disabled = true;
         try {
-          const res = await fetch(`/api/gallery/${img.id}`, { method: 'DELETE', credentials: 'include' });
+          const res = await fetchOrRedirect(`/api/gallery/${img.id}`, { method: 'DELETE' });
+          if (!res) return;
           if (res.ok) {
             loadGallery();
           } else {
@@ -149,12 +176,14 @@ form.addEventListener('submit', async e => {
     for (const file of formData.getAll('images')) {
       data.append('images', file);
     }
-    const uploadRes = await fetch('/api/upload', { method: 'POST', body: data, credentials: 'include' });
+    const uploadRes = await fetchOrRedirect('/api/upload', { method: 'POST', body: data });
+    if (!uploadRes) return;
     if (!uploadRes.ok) {
       console.error('Upload failed with status', uploadRes.status);
       throw new Error('Upload failed');
     }
-    const refreshRes = await fetch('/api/refresh-categories');
+    const refreshRes = await fetchOrRedirect('/api/refresh-categories');
+    if (!refreshRes) return;
     if (!refreshRes.ok) {
       console.error('Refresh failed with status', refreshRes.status);
       throw new Error('Refresh failed');

--- a/server/server.js
+++ b/server/server.js
@@ -37,6 +37,54 @@ const categoriesFile = path.join(__dirname, 'categories.json');
 const usersFile = path.join(__dirname, 'users.json');
 const upload = multer({ dest: path.join(publicDir, 'images') });
 
+function loadGalleryData() {
+  let images = [];
+  try {
+    images = JSON.parse(fs.readFileSync(galleryFile));
+  } catch (e) {
+    return [];
+  }
+
+  let changed = false;
+  let maxId = images.reduce((max, img) => {
+    const id = Number(img.id);
+    return Number.isFinite(id) && id > max ? id : max;
+  }, 0);
+
+  const normalised = images.map(img => {
+    const numericId = Number(img.id);
+    if (Number.isFinite(numericId)) {
+      if (numericId !== img.id) {
+        changed = true;
+        return { ...img, id: numericId };
+      }
+      return img;
+    }
+    changed = true;
+    const newId = ++maxId;
+    return { ...img, id: newId };
+  });
+
+  if (changed) {
+    fs.writeFileSync(galleryFile, JSON.stringify(normalised, null, 2));
+  }
+
+  return normalised;
+}
+
+function saveGalleryData(images) {
+  fs.writeFileSync(galleryFile, JSON.stringify(images, null, 2));
+}
+
+function nextGalleryId(images) {
+  return (
+    images.reduce((max, img) => {
+      const id = Number(img.id);
+      return Number.isFinite(id) && id > max ? id : max;
+    }, 0) + 1
+  );
+}
+
 function loadUsers() {
   try {
     return JSON.parse(fs.readFileSync(usersFile));
@@ -60,7 +108,7 @@ if (users.length === 0) {
 
 // Rebuilds categories.json using the first four images from each category
 function refreshCategories() {
-  const images = JSON.parse(fs.readFileSync(galleryFile));
+  const images = loadGalleryData();
   const categories = images.reduce((acc, img) => {
     const cat = img.category || 'inne';
     (acc[cat] = acc[cat] || []).push({
@@ -77,19 +125,20 @@ function refreshCategories() {
 }
 
 function ensureAuth(req, res, next) {
-  console.log(req.session);
   if (req.session && req.session.loggedIn) return next();
+  if (req.originalUrl.startsWith('/api/')) {
+    return res.status(401).json({ error: 'Brak autoryzacji' });
+  }
   res.redirect('/login');
 }
 
 app.get('/api/gallery', (req, res) => {
   const { mode } = req.query;
   if (mode === 'full' && !(req.session && req.session.loggedIn)) {
-    return res.redirect('/login');
+    return res.status(401).json({ error: 'Brak autoryzacji' });
   }
-  fs.readFile(galleryFile, (err, data) => {
-    if (err) return res.status(500).send('Błąd odczytu');
-    let images = JSON.parse(data);
+  try {
+    let images = loadGalleryData();
 
     const { category } = req.query;
     if (category) {
@@ -115,7 +164,9 @@ app.get('/api/gallery', (req, res) => {
     });
 
     res.json(mapped);
-  });
+  } catch (err) {
+    res.status(500).send('Błąd odczytu');
+  }
 });
 
 app.get('/api/categories', (req, res) => {
@@ -162,28 +213,29 @@ app.get('/api/logout', (req, res) => {
 });
 
 app.post('/api/upload', ensureAuth, upload.array('images'), (req, res) => {
-  const images = JSON.parse(fs.readFileSync(galleryFile));
+  const images = loadGalleryData();
+  let idCounter = nextGalleryId(images);
   const uploaded = req.files.map((file, idx) => {
     const img = {
-      id: Date.now() + idx,
+      id: idCounter + idx,
       filename: file.filename,
       category: req.body.category
     };
     images.push(img);
     return img;
   });
-  fs.writeFileSync(galleryFile, JSON.stringify(images, null, 2));
+  saveGalleryData(images);
   refreshCategories();
   res.json(uploaded);
 });
 
 app.delete('/api/gallery/:id', ensureAuth, (req, res) => {
-  const id = parseInt(req.params.id, 10);
-  const images = JSON.parse(fs.readFileSync(galleryFile));
+  const id = Number(req.params.id);
+  const images = loadGalleryData();
   const index = images.findIndex(i => i.id === id);
   if (index === -1) return res.status(404).end();
   const [img] = images.splice(index, 1);
-  fs.writeFileSync(galleryFile, JSON.stringify(images, null, 2));
+  saveGalleryData(images);
   try {
     fs.unlinkSync(path.join(publicDir, 'images', img.filename));
   } catch (e) {


### PR DESCRIPTION
## Summary
- return API 401 responses instead of login redirects when an admin session expires
- add a shared fetch helper in the dashboard to include credentials and redirect back to login on 401
- harden gallery refresh logic so upload/delete actions can run repeatedly without reloading the page

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5750e1b4083248b3cba042c03ab11