### PR TITLE
Limit gallery columns and spacing

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -232,10 +232,12 @@ body {
   text-align: center;
   margin-bottom: 2rem;
 }
+#gallery-grid,
+#gallery-all,
 .gallery .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1rem;
+  gap: 0.75rem;
+  grid-template-columns: 1fr;
 }
 .gallery .grid .item {
   position: relative;
@@ -252,11 +254,20 @@ body {
   transform: scale(1.1);
 }
 
-#gallery-grid,
-#gallery-all {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
+@media (min-width: 600px) {
+  #gallery-grid,
+  #gallery-all,
+  .gallery .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  #gallery-grid,
+  #gallery-all,
+  .gallery .grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
 }
 #gallery-grid .item,
 #gallery-all .item {


### PR DESCRIPTION
## Summary
- ensure gallery grids default to a single column on mobile and top out at three columns on large screens
- reduce gaps between gallery items for a tighter, consistent presentation across pages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d57e005a248324b2dfbbae56345088