### PR TITLE
Limit gallery columns and spacing

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -232,10 +232,12 @@ body {
   text-align: center;
   margin-bottom: 2rem;
 }
+#gallery-grid,
+#gallery-all,
 .gallery .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1rem;
+  gap: 0.75rem;
+  grid-template-columns: 1fr;
 }
 .gallery .grid .item {
   position: relative;
@@ -243,8 +245,7 @@ body {
 }
 .gallery .grid img {
   width: 100%;
-  height: 100%;
-  object-fit: cover;
+  height: auto;
   transition: transform 0.5s ease;
   display: block;
 }
@@ -252,11 +253,31 @@ body {
   transform: scale(1.1);
 }
 
-#gallery-grid,
-#gallery-all {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
+@media (min-width: 600px) {
+  #gallery-grid,
+  #gallery-all,
+  .gallery .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (min-width: 1024px) {
+  #gallery-grid,
+  #gallery-all,
+  .gallery .grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  .gallery .grid .item,
+  #gallery-grid .item,
+  #gallery-all .item {
+    aspect-ratio: 3 / 4;
+  }
+  .gallery .grid img,
+  #gallery-grid img,
+  #gallery-all img {
+    height: 100%;
+    object-fit: cover;
+  }
 }
 #gallery-grid .item,
 #gallery-all .item {
@@ -266,8 +287,7 @@ body {
 #gallery-grid img,
 #gallery-all img {
   width: 100%;
-  height: 100%;
-  object-fit: cover;
+  height: auto;
   transition: transform 0.5s ease;
   display: block;
 }


### PR DESCRIPTION
## Summary
- ensure gallery grids default to a single column on mobile and top out at three columns on large screens
- reduce gaps between gallery items for a tighter, consistent presentation across pages
- crop gallery images to a consistent portrait ratio on desktops while keeping their natural proportions on mobile

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d57e005a248324b2dfbbae56345088