### PR TITLE
Refine gallery portrait cropping on desktop

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -232,48 +232,58 @@ body {
   text-align: center;
   margin-bottom: 2rem;
 }
+#gallery-grid,
+#gallery-all,
 .gallery .grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1rem;
+  gap: 0.75rem;
+  grid-template-columns: 1fr;
 }
+#gallery-grid .item,
+#gallery-all .item,
 .gallery .grid .item {
   position: relative;
   overflow: hidden;
 }
+#gallery-grid img,
+#gallery-all img,
 .gallery .grid img {
   width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: transform 0.5s ease;
+  height: auto;
   display: block;
+  transition: transform 0.5s ease;
 }
+#gallery-grid .item:hover img,
+#gallery-all .item:hover img,
 .gallery .grid .item:hover img {
   transform: scale(1.1);
 }
 
-#gallery-grid,
-#gallery-all {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1rem;
+@media (min-width: 600px) {
+  #gallery-grid,
+  #gallery-all,
+  .gallery .grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
-#gallery-grid .item,
-#gallery-all .item {
-  position: relative;
-  overflow: hidden;
-}
-#gallery-grid img,
-#gallery-all img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  transition: transform 0.5s ease;
-  display: block;
-}
-#gallery-grid .item:hover img,
-#gallery-all .item:hover img {
-  transform: scale(1.1);
+
+@media (min-width: 1024px) {
+  #gallery-grid,
+  #gallery-all,
+  .gallery .grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+  #gallery-grid .item,
+  #gallery-all .item,
+  .gallery .grid .item {
+    aspect-ratio: 3 / 4;
+  }
+  #gallery-grid img,
+  #gallery-all img,
+  .gallery .grid img {
+    height: 100%;
+    object-fit: cover;
+  }
 }
 
 /* Opinie */


### PR DESCRIPTION
## Summary
- consolidate shared gallery styles so mobile retains natural image proportions
- enforce a consistent 3:4 portrait crop for gallery images on desktop viewports
- keep hover scaling behavior uniform across all gallery selectors

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d57e005a248324b2dfbbae56345088