### PR TITLE
Przywrócenie hero galerii do spójnego stylu

### DIFF
--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -224,6 +224,25 @@ body {
     padding-left: 1.5rem;
     border-radius: 0.35rem;
   }
+
+  .nav--solid {
+    background: var(--light);
+  }
+
+  .nav--solid > ul {
+    background: var(--light);
+    box-shadow: -12px 0 40px rgba(15, 15, 15, 0.12);
+  }
+
+  .nav--solid .submenu {
+    background: transparent;
+    border: none;
+    box-shadow: none;
+  }
+
+  .nav--solid .dropdown.open .submenu {
+    background: rgba(15, 15, 15, 0.05);
+  }
 }
 
 .phone {
@@ -296,6 +315,31 @@ body {
 
 .hero--sypialnia {
   background-image: url('https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=1600&q=80');
+}
+
+.hero--galeria {
+  background-image: url('https://images.unsplash.com/photo-1616628182501-0b6952dfa52d?auto=format&fit=crop&w=1600&q=80');
+  background-position: center;
+}
+
+.hero-content--gallery {
+  margin: clamp(3.5rem, 12vh, 7rem) auto 6rem;
+  max-width: min(620px, 90vw);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+}
+
+.hero-content--gallery .hero-title {
+  margin: 0 0 1rem;
+  font-size: clamp(2.65rem, 5vw, 3.4rem);
+  font-weight: 600;
+  letter-spacing: 0.015em;
+}
+
+.hero-content--gallery .hero-description {
+  margin: 0;
+  font-size: clamp(1rem, 2.4vw, 1.1rem);
+  line-height: 1.8;
+  color: rgba(255, 255, 255, 0.88);
 }
 
 .hero--lazienka {
@@ -436,6 +480,40 @@ body.lightbox-open {
   text-align: center;
 }
 
+.container--wide {
+  max-width: min(1260px, 95vw);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.container--narrow {
+  max-width: min(960px, 92vw);
+  margin: 0 auto;
+  text-align: left;
+}
+
+.subpage-header {
+  background: var(--bg);
+}
+
+.subpage-header__title {
+  padding: clamp(3.5rem, 10vw, 5rem) 1rem clamp(2rem, 6vw, 3rem);
+  border-bottom: 1px solid rgba(15, 15, 15, 0.08);
+}
+
+.subpage-header__title .container {
+  max-width: min(960px, 92vw);
+}
+
+.subpage-header__title h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 5vw, 3.1rem);
+  font-weight: 400;
+  letter-spacing: 0.04em;
+  text-align: center;
+  color: var(--text);
+}
+
 /* Oferta */
 .offer {
   text-align: center;
@@ -487,77 +565,123 @@ body.lightbox-open {
   text-align: center;
   margin-bottom: 2rem;
 }
+
 #gallery-grid,
-#gallery-all,
 .gallery .grid {
   display: grid;
-  gap: 0.75rem;
-  grid-template-columns: 1fr;
+  gap: clamp(0.85rem, 2vw, 1.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
-#gallery-grid {
-  margin-top: 2.5rem;
-}
+
 #gallery-grid .item,
-#gallery-all .item,
 .gallery .grid .item {
   position: relative;
   overflow: hidden;
+  border-radius: 18px;
+  background: var(--light);
+  box-shadow: 0 10px 28px rgba(15, 15, 15, 0.08);
 }
+
 #gallery-grid img,
-#gallery-all img,
 .gallery .grid img {
   width: 100%;
-  height: auto;
+  height: 100%;
+  object-fit: cover;
   display: block;
+  transition: transform 0.45s ease;
+}
+
+#gallery-grid .item:hover img,
+.gallery .grid .item:hover img {
+  transform: scale(1.08);
+}
+
+.gallery--full .container {
+  max-width: min(1260px, 95vw);
+  text-align: left;
+  padding: 0 1.5rem;
+}
+
+.gallery-collection {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(2rem, 4vw, 3.5rem);
+}
+
+.gallery-category {
+  background: var(--bg);
+  border-radius: 28px;
+  padding: clamp(1.75rem, 3vw, 2.75rem);
+  box-shadow: 0 12px 28px rgba(15, 15, 15, 0.06);
+}
+
+.gallery-category__title {
+  margin: 0 0 clamp(1.25rem, 2.5vw, 1.85rem);
+  font-size: clamp(1.65rem, 3vw, 2rem);
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.gallery-category__title::after {
+  content: "";
+  flex: 1;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(15, 15, 15, 0.14) 0%, rgba(15, 15, 15, 0) 100%);
+}
+
+.gallery-category__grid {
+  display: grid;
+  gap: clamp(1rem, 2.5vw, 1.75rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.gallery-category__item {
+  position: relative;
+  overflow: hidden;
+  border-radius: 20px;
+  aspect-ratio: 4 / 5;
+  box-shadow: 0 18px 40px rgba(15, 15, 15, 0.12);
+}
+
+.gallery-category__item img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
   transition: transform 0.5s ease;
 }
-#gallery-grid .item:hover img,
-#gallery-all .item:hover img,
-.gallery .grid .item:hover img {
-  transform: scale(1.1);
+
+.gallery-category__item:hover img {
+  transform: scale(1.08);
 }
 
-@media (min-width: 600px) {
-  #gallery-grid,
-  #gallery-all,
-  .gallery .grid {
-    grid-template-columns: repeat(2, 1fr);
-  }
-}
-@media (min-width: 768px) {
-  .hero--subpage .hero-content {
-    margin: clamp(5rem, 16vh, 8rem) auto 6rem;
+@media (max-width: 768px) {
+  .gallery-category {
+    border-radius: 22px;
+    padding: 1.5rem;
   }
 
-  .gallery.section .container {
-    max-width: min(1240px, 94vw);
-    padding: 0 0.5rem;
+  .gallery-category__title {
+    flex-direction: column;
+    align-items: flex-start;
   }
 
-  #gallery-grid,
-  #gallery-all,
-  .gallery .grid {
-    gap: 0.5rem;
+  .gallery-category__title::after {
+    display: none;
   }
 }
 
-@media (min-width: 1024px) {
-  .gallery.section .container {
-    max-width: min(1320px, 92vw);
-    padding: 0;
-  }
-
-  #gallery-grid,
-  #gallery-all,
-  .gallery .grid {
-    gap: 0.45rem;
+@media (min-width: 1200px) {
+  .gallery-category__grid {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   }
 }
 .gallery.section {
   background: var(--bg);
 }
 
-.gallery.section .container {
+.gallery.section:not(.gallery--full) .container {
   max-width: 1100px;
 }
 
@@ -569,6 +693,56 @@ body.lightbox-open {
   margin: 0 auto 2.5rem;
   max-width: 720px;
   color: rgba(51, 51, 51, 0.75);
+}
+
+.gallery-description .container {
+  text-align: left;
+  max-width: min(960px, 92vw);
+}
+
+.gallery-description h2 {
+  font-size: clamp(2.1rem, 3.5vw, 2.6rem);
+  margin: 0 0 1.5rem;
+}
+
+.gallery-description h3 {
+  font-size: clamp(1.4rem, 2.5vw, 1.85rem);
+  margin: 2.5rem 0 1.25rem;
+}
+
+.gallery-description p {
+  margin: 0 0 1.25rem;
+  color: rgba(51, 51, 51, 0.88);
+}
+
+.gallery-description__highlights {
+  list-style: none;
+  padding: 0;
+  margin: 2rem 0;
+  display: grid;
+  gap: 1.25rem;
+}
+
+.gallery-description__highlights li {
+  position: relative;
+  padding-left: 2.5rem;
+  line-height: 1.7;
+}
+
+.gallery-description__highlights li::before {
+  content: "\2713";
+  position: absolute;
+  left: 0;
+  top: 0.15rem;
+  font-size: 1rem;
+  color: var(--accent);
+  background: var(--light);
+  border-radius: 50%;
+  width: 1.75rem;
+  height: 1.75rem;
+  display: grid;
+  place-items: center;
+  box-shadow: 0 6px 15px rgba(0, 0, 0, 0.08);
 }
 
 .category-description .container {

--- a/docs/galeria.html
+++ b/docs/galeria.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="./css/styles.css" />
 </head>
 <body>
-  <header class="hero">
+  <header class="hero hero--subpage hero--galeria">
     <nav class="nav">
       <h1 class="logo"><a href="index.html"><img src="./images/logo.png" alt="Vikimeble logo" /></a></h1>
       <button class="menu-toggle" aria-label="Menu"></button>
@@ -29,14 +29,35 @@
         <li><a href="tel:787138178" class="phone">787 138 178</a></li>
       </ul>
     </nav>
-    <div class="hero-content">
-      <h2>Tworzymy meble, które kochasz</h2>
-      <p>Designerskie projekty z naturalnego drewna prosto z naszej pracowni.</p>
-      <a href="#gallery-all" class="btn cta">Zobacz ofertę</a>
+    <div class="hero-content hero-content--gallery">
+      <p class="hero-eyebrow">Portfolio Vikimeble</p>
+      <h1 class="hero-title">Galeria</h1>
+      <p class="hero-description">Zobacz nasze najciekawsze realizacje mebli na wymiar w jednym miejscu.</p>
     </div>
   </header>
 
-  <div id="gallery-all" class="gallery grid"></div>
+  <main>
+    <section class="gallery section gallery--full">
+      <div class="container container--wide">
+        <div id="gallery-all" class="gallery-collection"></div>
+      </div>
+    </section>
+
+    <section class="gallery-description section">
+      <div class="container container--narrow">
+        <h2>Meble na wymiar dopasowane do Twojego wnętrza</h2>
+        <p>Każda realizacja, którą pokazujemy w galerii, to efekt bliskiej współpracy z klientem oraz dbałości o detale na każdym etapie projektu. Rozpoczynamy od poznania stylu życia domowników, następnie przygotowujemy koncepcję, dobieramy materiały i kolorystykę, a na końcu dopracowujemy funkcjonalne rozwiązania, które sprawiają, że meble stają się integralną częścią przestrzeni.</p>
+        <p>Zdjęcia prezentują zarówno duże zabudowy wykonywane do całych pomieszczeń, jak i pojedyncze elementy, które nadają charakteru wnętrzu. Pokazujemy różnorodne układy, wykończenia i połączenia materiałów, aby zainspirować Cię do stworzenia własnej, spersonalizowanej aranżacji.</p>
+        <h3>Dlaczego warto przejrzeć nasze realizacje?</h3>
+        <ul class="gallery-description__highlights">
+          <li><strong>Realne projekty.</strong> Wszystkie prezentowane zestawy powstały na indywidualne zamówienie w domach naszych klientów.</li>
+          <li><strong>Sprawdzone rozwiązania.</strong> W galerii znajdziesz przykłady zabudów, które łączą ergonomię z estetyką, niezależnie od metrażu.</li>
+          <li><strong>Inspiracje materiałowe.</strong> Pokazujemy różne gatunki drewna, forniry i kolory frontów, aby łatwiej było dobrać styl dopasowany do Twojego wnętrza.</li>
+        </ul>
+        <p>Jeśli masz własny pomysł na meble, chętnie przygotujemy projekt i przedstawimy wizualizacje dopasowane do Twojej przestrzeni. Skontaktuj się z nami, aby omówić szczegóły współpracy.</p>
+      </div>
+    </section>
+  </main>
 
   <footer class="footer">
     <p>&copy; <span id="year"></span> Vikimeble</p>

--- a/docs/js/galeria.js
+++ b/docs/js/galeria.js
@@ -1,6 +1,7 @@
 // Generowanie pełnej galerii pogrupowanej według kategorii
 async function loadGallery() {
   const container = document.getElementById('gallery-all');
+  if (!container) return;
   try {
     const res = await fetch('/api/gallery?mode=full');
     const images = await res.json();
@@ -12,17 +13,43 @@ async function loadGallery() {
       return acc;
     }, {});
 
-    Object.entries(groups).forEach(([category, imgs]) => {
-      const header = document.createElement('h3');
-      header.textContent = category.charAt(0).toUpperCase() + category.slice(1);
-      container.appendChild(header);
+    const categoryLabels = {
+      kuchnia: 'Meble kuchenne',
+      salon: 'Meble salonowe',
+      sypialnia: 'Meble sypialniane',
+      lazienka: 'Meble łazienkowe',
+      inne: 'Meble na zamówienie'
+    };
+
+    const categoryOrder = ['kuchnia', 'salon', 'sypialnia', 'lazienka', 'inne'];
+    const sortedCategories = [
+      ...categoryOrder.filter(cat => groups[cat]),
+      ...Object.keys(groups).filter(cat => !categoryOrder.includes(cat))
+    ];
+
+    container.innerHTML = '';
+
+    sortedCategories.forEach(category => {
+      const imgs = groups[category];
+      if (!imgs || !imgs.length) return;
+
+      const section = document.createElement('section');
+      section.className = 'gallery-category';
+
+      const title = document.createElement('h3');
+      title.className = 'gallery-category__title';
+      title.textContent = categoryLabels[category] || category
+        .split(/[-_\s]+/)
+        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+        .join(' ');
+      section.appendChild(title);
 
       const grid = document.createElement('div');
-      grid.className = 'grid';
+      grid.className = 'gallery-category__grid';
 
       imgs.forEach(img => {
         const fig = document.createElement('figure');
-        fig.className = 'item';
+        fig.className = 'gallery-category__item';
         const image = document.createElement('img');
         image.src = '/images/' + img.filename;
         image.alt = img.alt || '';
@@ -30,7 +57,8 @@ async function loadGallery() {
         grid.appendChild(fig);
       });
 
-      container.appendChild(grid);
+      section.appendChild(grid);
+      container.appendChild(section);
 
       const lightboxItems = imgs.map(img => {
         const alt = img.alt || '';


### PR DESCRIPTION
## Summary
- zastąpiono prosty nagłówek na stronie galerii spójną sekcją hero z tłem zdjęciowym i ramką
- dodano dedykowane style hero dla galerii, aby zachować ciemny motyw i lepszą czytelność nagłówka

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5a5034eb083248194db34f121f6e5