### PR TITLE
Revamp homepage and add testimonials management

### DIFF
--- a/docs/admin/dashboard.html
+++ b/docs/admin/dashboard.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" href="../css/styles.css" />
 </head>
 <body class="admin-dashboard-body">
-  <nav class="nav nav--solid admin-nav">
+  <nav class="nav nav--solid nav--static admin-nav">
     <div class="admin-nav__left">
       <h1 class="logo"><a href="../index.html"><img src="../images/logo.png" alt="Vikimeble logo" /></a></h1>
       <span class="admin-nav__title">Panel administracyjny</span>
@@ -24,7 +24,7 @@
         <h2>Witaj w panelu zarządzania</h2>
         <p>Dodawaj i usuwaj zdjęcia z galerii oraz dbaj o aktualność oferty w kilku prostych krokach.</p>
       </div>
-      <div class="admin-hero__badge">Nowe: filtrowanie kategorii</div>
+      <div class="admin-hero__badge">Nowe: zarządzanie opiniami klientów</div>
     </section>
 
     <section class="admin-grid">
@@ -67,6 +67,57 @@
           <div class="admin-toolbar" id="gallery-toolbar"></div>
         </div>
         <div id="gallery-list" class="admin-gallery-list"></div>
+      </article>
+
+      <article class="admin-card admin-card--form admin-card--testimonials">
+        <div class="admin-card__header">
+          <div>
+            <h2>Dodaj opinię klienta</h2>
+            <p class="admin-card__subtitle">Uzupełnij dane, aby nowa opinia mogła pojawić się na stronie głównej.</p>
+          </div>
+        </div>
+        <form id="testimonial-form" class="admin-form admin-form--testimonial">
+          <div class="admin-form__grid admin-form__grid--testimonial">
+            <label class="admin-field">
+              <span>Autor</span>
+              <input type="text" name="author" maxlength="120" required />
+            </label>
+            <label class="admin-field">
+              <span>Ocena</span>
+              <select name="rating" required>
+                <option value="">Wybierz</option>
+                <option value="5">5</option>
+                <option value="4">4</option>
+                <option value="3">3</option>
+                <option value="2">2</option>
+                <option value="1">1</option>
+              </select>
+            </label>
+            <label class="admin-field admin-field--order">
+              <span>Kolejność</span>
+              <input type="number" name="order" min="1" step="1" placeholder="Automatyczna" />
+            </label>
+          </div>
+          <label class="admin-field admin-field--textarea">
+            <span>Treść opinii</span>
+            <textarea name="quote" rows="4" required></textarea>
+          </label>
+          <label class="admin-checkbox">
+            <input type="checkbox" name="published" checked />
+            <span>Publikuj opinię na stronie</span>
+          </label>
+          <button class="btn btn--wide" type="submit">Dodaj opinię</button>
+        </form>
+      </article>
+
+      <article class="admin-card admin-card--list admin-card--testimonials-list">
+        <div class="admin-card__header">
+          <div>
+            <h2>Zarządzaj opiniami</h2>
+            <p class="admin-card__subtitle">Edytuj treść, ocenę, kolejność oraz widoczność opinii.</p>
+          </div>
+        </div>
+        <div id="testimonials-list" class="admin-testimonials-list"></div>
       </article>
     </section>
   </main>

--- a/docs/admin/dashboard.js
+++ b/docs/admin/dashboard.js
@@ -2,6 +2,10 @@ const list = document.getElementById('gallery-list');
 const form = document.getElementById('upload-form');
 const fileInput = form.querySelector('input[type="file"]');
 const preview = document.getElementById('preview');
+const testimonialForm = document.getElementById('testimonial-form');
+const testimonialsContainer = document.getElementById('testimonials-list');
+
+let testimonialsData = [];
 
 // Dynamiczny filtr kategorii
 const filter = document.createElement('select');
@@ -190,7 +194,251 @@ function renderGallery() {
       container.appendChild(wrapper);
     });
     section.appendChild(container);
-    list.appendChild(section);
+  list.appendChild(section);
+  });
+}
+
+function getTestimonialPayload(formElement) {
+  const authorInput = formElement.querySelector('[name="author"]');
+  const ratingInput = formElement.querySelector('[name="rating"]');
+  const quoteInput = formElement.querySelector('[name="quote"]');
+  const orderInput = formElement.querySelector('[name="order"]');
+  const publishedInput = formElement.querySelector('[name="published"]');
+
+  const orderValue = orderInput && orderInput.value !== '' ? Number(orderInput.value) : undefined;
+
+  return {
+    author: authorInput ? authorInput.value.trim() : '',
+    rating: ratingInput ? Number(ratingInput.value) : undefined,
+    quote: quoteInput ? quoteInput.value.trim() : '',
+    order: Number.isFinite(orderValue) ? orderValue : undefined,
+    published: publishedInput ? Boolean(publishedInput.checked) : false
+  };
+}
+
+function renderTestimonialsAdmin() {
+  if (!testimonialsContainer) return;
+  testimonialsContainer.innerHTML = '';
+
+  if (!Array.isArray(testimonialsData) || testimonialsData.length === 0) {
+    const empty = document.createElement('p');
+    empty.classList.add('admin-empty', 'admin-empty--testimonials');
+    empty.textContent = 'Brak dodanych opinii.';
+    testimonialsContainer.appendChild(empty);
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  testimonialsData.forEach(testimonial => {
+    fragment.appendChild(createTestimonialItem(testimonial));
+  });
+  testimonialsContainer.appendChild(fragment);
+}
+
+function createTestimonialItem(testimonial) {
+  const formElement = document.createElement('form');
+  formElement.classList.add('admin-testimonial-item');
+  formElement.dataset.id = String(testimonial.id);
+
+  const grid = document.createElement('div');
+  grid.classList.add('admin-form__grid', 'admin-form__grid--testimonial');
+
+  const authorField = document.createElement('label');
+  authorField.className = 'admin-field';
+  authorField.innerHTML = '<span>Autor</span>';
+  const authorInput = document.createElement('input');
+  authorInput.type = 'text';
+  authorInput.name = 'author';
+  authorInput.required = true;
+  authorInput.maxLength = 120;
+  authorInput.value = testimonial.author || '';
+  authorField.appendChild(authorInput);
+
+  const ratingField = document.createElement('label');
+  ratingField.className = 'admin-field';
+  ratingField.innerHTML = '<span>Ocena</span>';
+  const ratingSelect = document.createElement('select');
+  ratingSelect.name = 'rating';
+  ratingSelect.required = true;
+  ['5', '4', '3', '2', '1'].forEach(value => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = value;
+    if (Number(value) === Number(testimonial.rating)) {
+      option.selected = true;
+    }
+    ratingSelect.appendChild(option);
+  });
+  ratingField.appendChild(ratingSelect);
+
+  const orderField = document.createElement('label');
+  orderField.className = 'admin-field admin-field--order';
+  orderField.innerHTML = '<span>Kolejność</span>';
+  const orderInput = document.createElement('input');
+  orderInput.type = 'number';
+  orderInput.name = 'order';
+  orderInput.min = '1';
+  orderInput.step = '1';
+  orderInput.value = testimonial.order ? String(testimonial.order) : '';
+  orderField.appendChild(orderInput);
+
+  grid.append(authorField, ratingField, orderField);
+  formElement.appendChild(grid);
+
+  const quoteField = document.createElement('label');
+  quoteField.className = 'admin-field admin-field--textarea';
+  quoteField.innerHTML = '<span>Treść opinii</span>';
+  const quoteTextarea = document.createElement('textarea');
+  quoteTextarea.name = 'quote';
+  quoteTextarea.rows = 3;
+  quoteTextarea.required = true;
+  quoteTextarea.value = testimonial.quote || '';
+  quoteField.appendChild(quoteTextarea);
+  formElement.appendChild(quoteField);
+
+  const checkboxLabel = document.createElement('label');
+  checkboxLabel.className = 'admin-checkbox';
+  const publishedInput = document.createElement('input');
+  publishedInput.type = 'checkbox';
+  publishedInput.name = 'published';
+  publishedInput.checked = Boolean(testimonial.published);
+  checkboxLabel.appendChild(publishedInput);
+  const checkboxText = document.createElement('span');
+  checkboxText.textContent = 'Opublikowana na stronie';
+  checkboxLabel.appendChild(checkboxText);
+  formElement.appendChild(checkboxLabel);
+
+  const actions = document.createElement('div');
+  actions.className = 'admin-testimonial-actions';
+  const saveButton = document.createElement('button');
+  saveButton.type = 'submit';
+  saveButton.className = 'btn btn--small';
+  saveButton.textContent = 'Zapisz zmiany';
+  const deleteButton = document.createElement('button');
+  deleteButton.type = 'button';
+  deleteButton.className = 'admin-delete-btn admin-delete-btn--inline';
+  deleteButton.textContent = 'Usuń';
+  actions.append(saveButton, deleteButton);
+  formElement.appendChild(actions);
+
+  formElement.addEventListener('submit', async event => {
+    event.preventDefault();
+    saveButton.disabled = true;
+    deleteButton.disabled = true;
+    try {
+      const payload = getTestimonialPayload(formElement);
+      const res = await fetchOrRedirect(`/api/admin/testimonials/${testimonial.id}`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!res) return;
+      if (!res.ok) {
+        let message = 'Nie udało się zaktualizować opinii.';
+        try {
+          const data = await res.json();
+          if (data && Array.isArray(data.errors)) {
+            message = data.errors.join('\n');
+          }
+        } catch (error) {
+          console.error('Nie udało się odczytać odpowiedzi serwera', error);
+        }
+        alert(message);
+        return;
+      }
+      await loadTestimonialsAdmin();
+    } catch (error) {
+      console.error('Aktualizacja opinii nie powiodła się', error);
+      alert('Nie udało się zapisać zmian.');
+    } finally {
+      saveButton.disabled = false;
+      deleteButton.disabled = false;
+    }
+  });
+
+  deleteButton.addEventListener('click', async () => {
+    const confirmed = window.confirm('Czy na pewno chcesz usunąć tę opinię?');
+    if (!confirmed) return;
+    deleteButton.disabled = true;
+    saveButton.disabled = true;
+    try {
+      const res = await fetchOrRedirect(`/api/admin/testimonials/${testimonial.id}`, { method: 'DELETE' });
+      if (!res) return;
+      if (!res.ok) {
+        alert('Nie udało się usunąć opinii.');
+        return;
+      }
+      await loadTestimonialsAdmin();
+    } catch (error) {
+      console.error('Usuwanie opinii nie powiodło się', error);
+      alert('Nie udało się usunąć opinii.');
+    } finally {
+      if (document.contains(formElement)) {
+        deleteButton.disabled = false;
+        saveButton.disabled = false;
+      }
+    }
+  });
+
+  return formElement;
+}
+
+async function loadTestimonialsAdmin() {
+  if (!testimonialsContainer) return;
+  const res = await fetchOrRedirect('/api/admin/testimonials');
+  if (!res) return;
+  if (!res.ok) {
+    console.error('Nie udało się pobrać opinii. Status:', res.status);
+    alert('Nie udało się pobrać listy opinii.');
+    return;
+  }
+  try {
+    testimonialsData = await res.json();
+  } catch (error) {
+    console.error('Nie udało się odczytać danych opinii', error);
+    testimonialsData = [];
+  }
+  renderTestimonialsAdmin();
+}
+
+if (testimonialForm) {
+  const createButton = testimonialForm.querySelector('button[type="submit"]');
+  testimonialForm.addEventListener('submit', async event => {
+    event.preventDefault();
+    if (createButton) createButton.disabled = true;
+    try {
+      const payload = getTestimonialPayload(testimonialForm);
+      const res = await fetchOrRedirect('/api/admin/testimonials', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      if (!res) return;
+      if (!res.ok) {
+        let message = 'Nie udało się dodać opinii.';
+        try {
+          const data = await res.json();
+          if (data && Array.isArray(data.errors)) {
+            message = data.errors.join('\n');
+          }
+        } catch (error) {
+          console.error('Nie udało się odczytać odpowiedzi serwera', error);
+        }
+        alert(message);
+        return;
+      }
+      testimonialForm.reset();
+      const publishedCheckbox = testimonialForm.querySelector('[name="published"]');
+      if (publishedCheckbox) {
+        publishedCheckbox.checked = true;
+      }
+      await loadTestimonialsAdmin();
+    } catch (error) {
+      console.error('Nie udało się dodać opinii', error);
+      alert('Nie udało się dodać opinii. Spróbuj ponownie.');
+    } finally {
+      if (createButton) createButton.disabled = false;
+    }
   });
 }
 
@@ -233,6 +481,7 @@ form.addEventListener('submit', async e => {
 
 loadGallery();
 refreshPreviews();
+loadTestimonialsAdmin();
 
 // Okresowe odświeżanie miniatur, aby nowe zdjęcia pojawiały się
 // bez konieczności przeładowywania strony głównej.

--- a/docs/css/styles.css
+++ b/docs/css/styles.css
@@ -4,6 +4,7 @@
   --text: #333;
   --accent: #000;
   --light: #fff;
+  --nav-height: 82px;
 }
 
 html {
@@ -18,6 +19,27 @@ body {
   line-height: 1.6;
 }
 
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+textarea:focus-visible,
+select:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 /* Przyciski */
 .btn {
   display: inline-block;
@@ -26,10 +48,16 @@ body {
   padding: 0.75rem 1.5rem;
   border-radius: 4px;
   text-decoration: none;
-  transition: background 0.3s ease;
+  border: none;
+  cursor: pointer;
+  transition: background 0.3s ease, transform 0.3s ease;
 }
 .btn:hover {
   background: #333;
+  transform: translateY(-2px);
+}
+.btn:focus-visible {
+  transform: translateY(-2px);
 }
 
 /* Hero */
@@ -66,27 +94,35 @@ body {
   position: sticky;
   top: 0;
   z-index: 2200;
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1rem 2rem;
-  background: rgba(0,0,0,0.6);
-  backdrop-filter: blur(4px);
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(8px);
 }
-.nav > ul {
+
+.nav__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: clamp(1rem, 2vw, 1.75rem);
+  padding: clamp(0.75rem, 2vw, 1.25rem) 0;
+  text-align: left;
+}
+
+.nav__inner > ul {
   list-style: none;
   display: flex;
-  gap: 1.5rem;
+  align-items: center;
+  gap: clamp(1.1rem, 2.5vw, 1.8rem);
   margin: 0;
   padding: 0;
   z-index: 1;
+  flex-wrap: nowrap;
 }
 
-.nav li {
+.nav__inner li {
   margin: 0;
 }
 
-.nav > ul > li > a {
+.nav__inner > ul > li > a {
   color: var(--light);
   text-decoration: none;
   display: block;
@@ -94,10 +130,14 @@ body {
   border-radius: 999px;
   font-weight: 500;
   transition: background 0.25s ease, color 0.25s ease;
+  white-space: nowrap;
 }
-.nav > ul > li > a:hover,
-.nav > ul > li > a:focus-visible {
-
+.nav__inner > ul > li > a.is-active {
+  background: rgba(255, 255, 255, 0.28);
+  color: var(--light);
+}
+.nav__inner > ul > li > a:hover,
+.nav__inner > ul > li > a:focus-visible {
   background: rgba(255, 255, 255, 0.18);
   color: var(--light);
 }
@@ -169,13 +209,14 @@ body {
   box-shadow: 0 8px 28px rgba(15, 15, 15, 0.08);
 }
 
-.nav--solid > ul > li > a {
+.nav--solid .nav__inner > ul > li > a {
   color: var(--text);
   background: transparent;
 }
 
-.nav--solid > ul > li > a:hover,
-.nav--solid > ul > li > a:focus-visible {
+.nav--solid .nav__inner > ul > li > a.is-active,
+.nav--solid .nav__inner > ul > li > a:hover,
+.nav--solid .nav__inner > ul > li > a:focus-visible {
   background: rgba(15, 15, 15, 0.08);
   color: var(--text);
 }
@@ -204,6 +245,9 @@ body {
 }
 
 @media (max-width: 768px) {
+  :root {
+    --nav-height: 64px;
+  }
   .submenu {
     position: static;
     margin: 0;
@@ -221,12 +265,14 @@ body {
   .nav {
     position: sticky;
     top: 0;
-    height: 60px;
     background: rgba(0,0,0,0.65);
     backdrop-filter: blur(6px);
     z-index: 2200;
   }
-  .nav > ul {
+  .nav__inner {
+    padding: 0 0;
+  }
+  .nav__inner > ul {
     position: fixed;
     top: 0;
     right: -100%;
@@ -243,13 +289,13 @@ body {
   .menu-toggle {
     display: block;
   }
-  .nav.open > ul {
+  .nav.open .nav__inner > ul {
     right: 0;
   }
-  .nav > ul > li {
+  .nav__inner > ul > li {
     width: 100%;
   }
-  .nav > ul > li > a {
+  .nav__inner > ul > li > a {
     padding: 0.75rem 1rem;
     border-radius: 0.5rem;
   }
@@ -269,7 +315,7 @@ body {
     background: var(--light);
   }
 
-  .nav--solid > ul {
+  .nav--solid .nav__inner > ul {
     background: var(--light);
     box-shadow: -12px 0 40px rgba(15, 15, 15, 0.12);
   }
@@ -282,6 +328,15 @@ body {
 
   .nav--solid .dropdown.open .submenu {
     background: rgba(15, 15, 15, 0.05);
+  }
+
+  .hero-content--home {
+    margin: clamp(4rem, 20vh, 6.5rem) auto clamp(3rem, 12vh, 5rem);
+    text-align: center;
+  }
+
+  .hero-actions {
+    justify-content: center;
   }
 }
 
@@ -303,9 +358,19 @@ body {
 }
 .hero-content {
   text-align: center;
-  margin: auto;
-  backdrop-filter: brightness(0.8);
-  padding: 2rem;
+  margin: clamp(4rem, 15vh, 7rem) auto clamp(3rem, 10vh, 6rem);
+  padding: clamp(2rem, 4vw, 3rem);
+}
+
+.hero-content--home {
+  max-width: min(780px, 92vw);
+  text-align: left;
+  margin-left: 0;
+  margin-right: auto;
+  background: rgba(0, 0, 0, 0.58);
+  border-radius: 24px;
+  box-shadow: 0 35px 65px rgba(0, 0, 0, 0.4);
+  backdrop-filter: blur(8px);
 }
 
 .hero--subpage .hero-content {
@@ -337,12 +402,38 @@ body {
   margin-bottom: 1.5rem;
   line-height: 1.8;
 }
+.hero-title,
+.hero-content h1,
 .hero-content h2 {
-  font-size: 2.5rem;
-  margin-bottom: 1rem;
+  font-size: clamp(2.5rem, 6vw, 3.8rem);
+  margin: 0 0 1.25rem;
+  letter-spacing: 0.01em;
+  font-weight: 600;
 }
 .hero-content p {
-  margin-bottom: 2rem;
+  margin: 0 0 2rem;
+  line-height: 1.8;
+}
+
+.hero-lead {
+  color: rgba(255, 255, 255, 0.88);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.btn--ghost {
+  background: transparent;
+  color: var(--light);
+  border: 1px solid rgba(255, 255, 255, 0.65);
+}
+
+.btn--ghost:hover,
+.btn--ghost:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
 }
 
 .hero--kuchnia {
@@ -515,11 +606,59 @@ body.lightbox-open {
 .section {
   padding: 4rem 1rem;
 }
+.section,
+.hero {
+  scroll-margin-top: var(--nav-height);
+}
 .container {
   max-width: 1000px;
   margin: 0 auto;
   padding: 0 1rem;
   text-align: center;
+}
+
+.section-heading {
+  max-width: min(760px, 92vw);
+  margin: 0 auto clamp(2rem, 4vw, 3.5rem);
+  text-align: center;
+}
+
+.section-heading h2 {
+  margin: 0 0 1rem;
+  font-size: clamp(2rem, 4.5vw, 2.8rem);
+  letter-spacing: 0.01em;
+  font-weight: 600;
+}
+
+.section-heading--left {
+  text-align: left;
+  margin-left: 0;
+}
+
+.section-heading--left h2 {
+  text-align: left;
+}
+
+.section-eyebrow {
+  display: inline-block;
+  margin: 0 0 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.28rem;
+  font-size: 0.82rem;
+  font-weight: 500;
+  color: rgba(51, 51, 51, 0.6);
+}
+
+.section-lead {
+  margin: 0 auto clamp(2rem, 4vw, 3rem);
+  max-width: 720px;
+  color: rgba(51, 51, 51, 0.78);
+  font-size: 1.02rem;
+  line-height: 1.8;
+}
+
+.section-heading--left .section-lead {
+  margin-left: 0;
 }
 
 .container--wide {
@@ -556,52 +695,200 @@ body.lightbox-open {
   color: var(--text);
 }
 
-/* Oferta */
-.offer {
-  text-align: center;
-}
-.offer h3 {
-  text-align: center;
-  margin-bottom: 2rem;
+/* Oferta / kategorie */
+.categories {
+  background: var(--bg);
 }
 
-.offer-grid {
+.category-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 1.5rem;
-  margin-top: 2rem;
+  gap: clamp(1.5rem, 4vw, 2.75rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
-.offer-item {
+.category-card {
+  position: relative;
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+}
+
+.category-card__link {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  background: var(--light);
-  padding: 3rem 1rem;
-  border-radius: 8px;
+  flex-direction: column;
   text-decoration: none;
   color: inherit;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  height: 100%;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
 }
 
-.offer-item:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-}
-
-  .preview-grid {
+.category-card__media {
+  position: relative;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-rows: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+  aspect-ratio: 4 / 3;
+  border-radius: 22px;
+  overflow: hidden;
+  background: linear-gradient(135deg, rgba(0, 0, 0, 0.08), rgba(0, 0, 0, 0.02));
 }
 
-.preview-grid img {
+.category-card__media::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: 22px;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.15);
+  pointer-events: none;
+}
+
+.category-card__media img {
   width: 100%;
-  height: 250px;
+  height: 100%;
   object-fit: cover;
+  border-radius: 18px;
+  transition: transform 0.6s ease;
+  box-shadow: 0 14px 32px rgba(15, 15, 15, 0.12);
 }
 
+.category-card__media img:first-child {
+  grid-column: 1 / -1;
+  grid-row: 1 / span 1;
+}
+
+.category-card__media img:nth-child(2) {
+  grid-column: 1 / span 1;
+  grid-row: 2;
+}
+
+.category-card__media img:nth-child(3) {
+  grid-column: 2 / span 1;
+  grid-row: 2;
+}
+
+.category-card__media img:nth-child(n + 4) {
+  display: none;
+}
+
+.category-card__content {
+  position: relative;
+  background: var(--light);
+  padding: clamp(1.5rem, 3vw, 2rem);
+  border-radius: 26px;
+  box-shadow: 0 25px 45px rgba(15, 15, 15, 0.12);
+  min-height: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.category-card__content h3 {
+  margin: 0;
+  font-size: clamp(1.35rem, 2.6vw, 1.7rem);
+  font-weight: 600;
+}
+
+.category-card__content p {
+  margin: 0;
+  line-height: 1.7;
+  color: rgba(51, 51, 51, 0.78);
+}
+
+.category-card__cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+  color: var(--accent);
+  margin-top: auto;
+}
+
+.category-card__cta::after {
+  content: '\2192';
+  font-size: 1rem;
+  transition: transform 0.3s ease;
+}
+
+@media (hover: hover) {
+  .category-card:hover {
+    transform: translateY(-6px);
+  }
+
+  .category-card:hover .category-card__media img {
+    transform: scale(1.05);
+  }
+
+  .category-card:hover .category-card__cta::after {
+    transform: translateX(4px);
+  }
+}
+
+@media (max-width: 768px) {
+  .category-grid {
+    grid-template-columns: repeat(2, minmax(160px, 1fr));
+    gap: 1.25rem;
+  }
+
+  .category-card__content {
+    min-height: 220px;
+  }
+}
+
+.about {
+  background: var(--light);
+}
+
+.about__content {
+  display: grid;
+  gap: clamp(2rem, 5vw, 3rem);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: start;
+}
+
+.about__text p {
+  margin: 0 0 1.5rem;
+  line-height: 1.9;
+}
+
+.about__text p:last-child {
+  margin-bottom: 0;
+}
+
+.about__highlights {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.about__highlights li {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  font-weight: 500;
+  color: rgba(51, 51, 51, 0.88);
+}
+
+.about__highlights li span:first-child {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.75rem;
+  height: 1.75rem;
+  border-radius: 50%;
+  background: rgba(0, 0, 0, 0.08);
+  font-weight: 600;
+  color: var(--accent);
+  flex-shrink: 0;
+}
+
+.about__highlights li span:last-child {
+  flex: 1;
+  line-height: 1.7;
+}
 /* Galeria */
 .gallery h3 {
   text-align: center;
@@ -731,7 +1018,7 @@ body.lightbox-open {
   margin-bottom: 0.75rem;
 }
 
-.section-lead {
+.gallery.section .section-lead {
   margin: 0 auto 2.5rem;
   max-width: 720px;
   color: rgba(51, 51, 51, 0.75);
@@ -995,63 +1282,305 @@ body.lightbox-open {
 }
 
 /* Opinie */
-.testimonials h3 {
-  text-align: center;
-  margin-bottom: 2rem;
+.testimonials {
+  background: var(--bg);
 }
-.testimonials .cards {
+
+.testimonials-carousel {
+  position: relative;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: clamp(1rem, 3vw, 2rem);
+  margin-top: clamp(1rem, 3vw, 2rem);
+}
+
+.testimonials-viewport {
+  overflow: hidden;
+  border-radius: 24px;
+}
+
+
+.testimonials-track {
   display: flex;
-  flex-wrap: wrap;
-  justify-content: center;
-  gap: 1.5rem;
+  gap: clamp(1.25rem, 3vw, 2rem);
+  transition: transform 0.45s ease;
+  padding: 0.25rem 0;
+  will-change: transform;
 }
-.testimonials .card {
+
+.testimonial-card {
   background: var(--light);
-  padding: 2rem;
-  border-radius: 8px;
-  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-  max-width: 300px;
+  padding: clamp(1.75rem, 3vw, 2.4rem);
+  border-radius: 26px;
+  box-shadow: 0 25px 45px rgba(15, 15, 15, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-height: 240px;
+  flex: 0 0 auto;
 }
-.testimonials .card p {
+
+.testimonial-quote {
+  margin: 0;
+  font-size: 1.02rem;
+  line-height: 1.8;
+  color: rgba(51, 51, 51, 0.85);
   font-style: italic;
-  margin-bottom: 1rem;
+}
+
+.testimonial-author {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.testimonial-rating {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  color: #f4b400;
+  font-size: 0.95rem;
+}
+
+.testimonial-rating span {
+  letter-spacing: 0.12em;
+}
+
+.testimonials-control {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+  border: 1px solid rgba(15, 15, 15, 0.15);
+  background: var(--light);
+  display: grid;
+  place-items: center;
+  font-size: 1.25rem;
+  color: var(--text);
+  cursor: pointer;
+  transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease, transform 0.3s ease;
+}
+
+.testimonials-control:hover:not(:disabled),
+.testimonials-control:focus-visible:not(:disabled) {
+  background: var(--text);
+  color: var(--light);
+  border-color: var(--text);
+  transform: translateY(-2px);
+}
+
+.testimonials-control:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.testimonials-control:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.testimonials-empty {
+  margin: clamp(1rem, 3vw, 1.75rem) auto 0;
+  max-width: 540px;
+  text-align: center;
+  color: rgba(51, 51, 51, 0.7);
+  font-style: italic;
+}
+
+@media (max-width: 768px) {
+  .testimonials-carousel {
+    gap: 0.75rem;
+  }
+
+  .testimonials-control {
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+
+  .testimonials-viewport {
+    border-radius: 20px;
+  }
+
+  .testimonial-card {
+    min-height: 220px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .testimonials-track {
+    transition: none;
+  }
+
+  .testimonials-control:hover:not(:disabled),
+  .testimonials-control:focus-visible:not(:disabled),
+  .btn:hover,
+  .btn:focus-visible {
+    transform: none;
+  }
+
+  .category-card:hover,
+  .category-card:hover .category-card__cta::after,
+  .category-card:hover .category-card__media img {
+    transform: none;
+  }
 }
 
 /* Kontakt */
-.contact h3 {
-  text-align: center;
-  margin-bottom: 2rem;
+.contact {
+  background: var(--light);
 }
+
 .contact-wrapper {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  gap: 2rem;
+  gap: clamp(2rem, 5vw, 3.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  align-items: start;
 }
-.contact-form input,
-.contact-form textarea {
+
+.contact-form {
+  background: var(--bg);
+  border-radius: 26px;
+  box-shadow: 0 25px 45px rgba(15, 15, 15, 0.12);
+  padding: clamp(1.75rem, 3vw, 2.5rem);
+  display: grid;
+  gap: 1.25rem;
+}
+
+.contact-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-weight: 500;
+  color: rgba(51, 51, 51, 0.82);
+}
+
+.contact-field span {
+  font-size: 0.95rem;
+}
+
+.contact-field input,
+.contact-field textarea {
   width: 100%;
-  padding: 0.75rem;
-  margin-bottom: 1rem;
-  border: 1px solid #ccc;
-  border-radius: 4px;
+  padding: 0.9rem 1rem;
+  border: 1px solid rgba(15, 15, 15, 0.12);
+  border-radius: 14px;
   font-family: inherit;
+  font-size: 1rem;
+  background: var(--light);
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
 }
-.contact-form textarea {
-  min-height: 120px;
+
+.contact-field input:focus-visible,
+.contact-field textarea:focus-visible {
+  border-color: rgba(0, 0, 0, 0.45);
+  box-shadow: 0 0 0 4px rgba(0, 0, 0, 0.08);
+}
+
+.contact-field textarea {
+  min-height: 140px;
   resize: vertical;
 }
-.contact-info p {
-  margin: 0 0 1rem;
+
+.contact-submit {
+  align-self: start;
+  padding: 0.9rem 2.4rem;
+  font-size: 1rem;
+}
+
+.contact-info {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.contact-card {
+  background: var(--bg);
+  border-radius: 24px;
+  padding: clamp(1.75rem, 3vw, 2.25rem);
+  box-shadow: 0 18px 35px rgba(15, 15, 15, 0.12);
+}
+
+.contact-card h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1.25rem;
+  font-weight: 600;
+}
+
+.contact-card p,
+.contact-card address {
+  margin: 0 0 0.85rem;
+  color: rgba(51, 51, 51, 0.78);
+  font-style: normal;
+  line-height: 1.7;
+}
+
+.contact-card p:last-child,
+.contact-card address:last-child {
+  margin-bottom: 0;
+}
+
+.contact-link {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+.contact-link:hover,
+.contact-link:focus-visible {
+  text-decoration: underline;
+}
+
+@media (max-width: 768px) {
+  .contact-wrapper {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .contact-submit {
+    width: 100%;
+    justify-content: center;
+    text-align: center;
+  }
 }
 
 /* Stopka */
 .footer {
-  text-align: center;
-  padding: 2rem 1rem;
-  background: #eee;
+  background: #111;
+  color: rgba(255, 255, 255, 0.85);
+  padding: 2.5rem 1rem;
 }
-.footer a {
-  color: inherit;
+
+.footer .container {
+  max-width: min(1260px, 95vw);
+  margin: 0 auto;
+  padding: 0 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+  text-align: left;
+}
+
+.footer p {
+  margin: 0;
+}
+
+.footer-link {
+  color: var(--light);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.footer-link:hover,
+.footer-link:focus-visible {
+  text-decoration: underline;
+}
+
+@media (max-width: 600px) {
+  .footer .container {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
 }
 
 /* Animacje */
@@ -1331,6 +1860,10 @@ body.lightbox-open {
   gap: 1.5rem;
 }
 
+.admin-form__grid--testimonial {
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+}
+
 .admin-field {
   display: flex;
   flex-direction: column;
@@ -1338,8 +1871,29 @@ body.lightbox-open {
   font-weight: 500;
 }
 
+.admin-field--textarea textarea {
+  min-height: 140px;
+  resize: vertical;
+}
+
+.admin-checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.95rem;
+  color: #4b4b4b;
+}
+
+.admin-checkbox input {
+  width: 1.1rem;
+  height: 1.1rem;
+  border-radius: 0.35rem;
+  border: 1px solid rgba(0, 0, 0, 0.25);
+}
+
 .admin-field select,
-.admin-field input {
+.admin-field input,
+.admin-field textarea {
   border-radius: 0.85rem;
   border: 1px solid rgba(0, 0, 0, 0.12);
   padding: 0.9rem 1rem;
@@ -1349,7 +1903,8 @@ body.lightbox-open {
 }
 
 .admin-field select:focus,
-.admin-field input:focus {
+.admin-field input:focus,
+.admin-field textarea:focus {
   outline: none;
   border-color: rgba(0, 0, 0, 0.3);
   box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.08);
@@ -1475,6 +2030,51 @@ body.lightbox-open {
 .admin-delete-btn:disabled {
   opacity: 0.6;
   cursor: progress;
+}
+
+.admin-testimonials-list {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.admin-testimonial-item {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(15, 15, 15, 0.08);
+  padding: clamp(1.25rem, 2.5vw, 1.75rem);
+  box-shadow: 0 20px 45px rgba(15, 15, 15, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.admin-testimonial-item textarea {
+  min-height: 110px;
+}
+
+.admin-testimonial-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.btn--small {
+  padding: 0.65rem 1.4rem;
+  font-size: 0.9rem;
+  border-radius: 0.75rem;
+}
+
+.admin-delete-btn--inline {
+  padding: 0.65rem 1.4rem;
+  border-radius: 0.75rem;
+}
+
+.admin-empty--testimonials {
+  margin: 0;
+  color: #6b6b6b;
+  font-size: 0.95rem;
 }
 
 .admin-empty {

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,106 +4,207 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Vikimeble</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="./css/styles.css" />
 </head>
-<body>
-  <header class="hero">
-    <nav class="nav">
-      <h1 class="logo"><a href="index.html"><img src="./images/logo.png" alt="Vikimeble logo" /></a></h1>
-      <button class="menu-toggle" aria-label="Menu"></button>
-      <ul>
-        <li><a href="galeria.html">Galeria</a></li>
-        <li class="dropdown">
-          <a href="#">Oferta</a>
-          <ul class="submenu">
-            <li><a href="kuchnia.html">Kuchnia</a></li>
-            <li><a href="salon.html">Salon</a></li>
-            <li><a href="sypialnia.html">Sypialnia</a></li>
-            <li><a href="lazienka.html">Łazienka</a></li>
-            <li><a href="inne.html">Inne</a></li>
-          </ul>
-        </li>
-        <li><a href="#contact">Kontakt</a></li>
-        <li><a href="#about">O nas</a></li>
-        <li><a href="tel:787138178" class="phone">787 138 178</a></li>
-      </ul>
+<body class="home-page">
+  <header class="hero hero--home" id="top">
+    <nav class="nav" aria-label="Główne">
+      <div class="nav__inner container--wide">
+        <h1 class="logo"><a href="index.html"><img src="./images/logo.png" alt="Vikimeble logo" width="140" height="48" /></a></h1>
+        <button class="menu-toggle" aria-label="Menu" aria-expanded="false" aria-controls="primary-navigation"></button>
+        <ul id="primary-navigation">
+          <li><a href="galeria.html">Galeria</a></li>
+          <li class="dropdown">
+            <a href="#offer" aria-haspopup="true" aria-expanded="false">Oferta</a>
+            <ul class="submenu" aria-label="Podmenu oferta">
+              <li><a href="kuchnia.html">Kuchnia</a></li>
+              <li><a href="salon.html">Salon</a></li>
+              <li><a href="sypialnia.html">Sypialnia</a></li>
+              <li><a href="lazienka.html">Łazienka</a></li>
+              <li><a href="inne.html">Inne</a></li>
+            </ul>
+          </li>
+          <li><a href="#about">O nas</a></li>
+          <li><a href="#contact">Kontakt</a></li>
+          <li><a href="tel:787138178" class="phone">787 138 178</a></li>
+        </ul>
+      </div>
     </nav>
-    <div class="hero-content">
-      <h2>Tworzymy meble, które kochasz</h2>
-      <p>Designerskie projekty z naturalnego drewna prosto z naszej pracowni.</p>
+    <div class="hero-content hero-content--home container--wide">
+      <p class="hero-eyebrow">Pracownia mebli na wymiar</p>
+      <h1 class="hero-title">Rzemieślnicze meble tworzone dla Twojego wnętrza</h1>
+      <p class="hero-lead">Projektujemy i wykonujemy kuchnie, zabudowy oraz meble wolnostojące z najwyższej jakości drewna. Od pierwszego szkicu po montaż – dbamy o każdy detal.</p>
+      <div class="hero-actions">
+        <a href="#offer" class="btn">Poznaj ofertę</a>
+        <a href="#contact" class="btn btn--ghost">Umów konsultację</a>
+      </div>
     </div>
   </header>
 
-  <section id="offer" class="offer section reveal">
-    <h3>Oferta</h3>
-    <section class="category">
-      <h4>Kuchnia</h4>
-      <div id="kuchnia-preview" class="preview-grid"></div>
-    </section>
-    <section class="category">
-      <h4>Salon</h4>
-      <div id="salon-preview" class="preview-grid"></div>
-    </section>
-    <section class="category">
-      <h4>Sypialnia</h4>
-      <div id="sypialnia-preview" class="preview-grid"></div>
-    </section>
-    <section class="category">
-      <h4>Łazienka</h4>
-      <div id="lazienka-preview" class="preview-grid"></div>
-    </section>
-    <section class="category">
-      <h4>Inne</h4>
-      <div id="inne-preview" class="preview-grid"></div>
-    </section>
-  </section>
-
-  <section id="about" class="about section reveal">
-    <div class="container">
-      <h3>O nas</h3>
-      <p>Vikimeble to rodzinna manufaktura mebli premium. Łączymy tradycyjne rzemiosło z
-        nowoczesnym designem, tworząc unikalne elementy wystroju, które przetrwają pokolenia.</p>
-    </div>
-  </section>
-  <section id="testimonials" class="testimonials section reveal">
-    <h3>Opinie klientów</h3>
-    <div class="cards">
-      <article class="card">
-        <p>„Stół od Vikimeble to dzieło sztuki. Solidny i przepiękny.”</p>
-        <span class="author">– Anna</span>
-      </article>
-      <article class="card">
-        <p>„Profesjonalna obsługa i meble najwyższej jakości.”</p>
-        <span class="author">– Michał</span>
-      </article>
-      <article class="card">
-        <p>„Nasza kuchnia wygląda teraz jak z katalogu.”</p>
-        <span class="author">– Katarzyna</span>
-      </article>
-    </div>
-  </section>
-
-  <section id="contact" class="contact section reveal">
-    <h3>Kontakt</h3>
-    <div class="contact-wrapper">
-      <form class="contact-form">
-        <input type="text" name="name" placeholder="Imię i nazwisko" required />
-        <input type="email" name="email" placeholder="Email" required />
-        <textarea name="message" placeholder="Wiadomość" required></textarea>
-        <button type="submit" class="btn">Wyślij</button>
-      </form>
-      <div class="contact-info">
-        <p><strong>Vikimeble Firma Produkcyjno-Usługowa Piotr Jedziniak</strong></p>
-        <p>39-208 Głobikowa 99</p>
-        <p>tel. 787 138 178<br />biuro@vikimeble.pl</p>
+  <main>
+    <section id="offer" class="categories section reveal">
+      <div class="container container--wide">
+        <div class="section-heading">
+          <p class="section-eyebrow">Oferta</p>
+          <h2>Meble skrojone pod Twoją przestrzeń</h2>
+          <p class="section-lead">Tworzymy autorskie projekty dopasowane do stylu wnętrza i codziennych rytuałów domowników. Zobacz, w czym się specjalizujemy.</p>
+        </div>
+        <div class="category-grid" role="list">
+          <article class="category-card" role="listitem">
+            <a href="kuchnia.html" class="category-card__link">
+              <div class="category-card__media" id="kuchnia-preview" aria-hidden="true"></div>
+              <div class="category-card__content">
+                <h3>Kuchnie na wymiar</h3>
+                <p>Precyzyjnie zaplanowane zabudowy z naturalnych materiałów, które organizują przestrzeń pracy.</p>
+                <span class="category-card__cta">Zobacz realizacje</span>
+              </div>
+            </a>
+          </article>
+          <article class="category-card" role="listitem">
+            <a href="lazienka.html" class="category-card__link">
+              <div class="category-card__media" id="lazienka-preview" aria-hidden="true"></div>
+              <div class="category-card__content">
+                <h3>Łazienki</h3>
+                <p>Zabudowy odporne na wilgoć, łączące funkcjonalność z wysmakowanymi detalami.</p>
+                <span class="category-card__cta">Zobacz realizacje</span>
+              </div>
+            </a>
+          </article>
+          <article class="category-card" role="listitem">
+            <a href="salon.html" class="category-card__link">
+              <div class="category-card__media" id="salon-preview" aria-hidden="true"></div>
+              <div class="category-card__content">
+                <h3>Salony i strefy dzienne</h3>
+                <p>Biblioteki, meble RTV i stoły, które budują charakter wspólnych przestrzeni.</p>
+                <span class="category-card__cta">Zobacz realizacje</span>
+              </div>
+            </a>
+          </article>
+          <article class="category-card" role="listitem">
+            <a href="sypialnia.html" class="category-card__link">
+              <div class="category-card__media" id="sypialnia-preview" aria-hidden="true"></div>
+              <div class="category-card__content">
+                <h3>Sypialnie i garderoby</h3>
+                <p>Atmosferyczne wnętrza z idealnie dopasowaną zabudową i przemyślanym oświetleniem.</p>
+                <span class="category-card__cta">Zobacz realizacje</span>
+              </div>
+            </a>
+          </article>
+          <article class="category-card" role="listitem">
+            <a href="inne.html" class="category-card__link">
+              <div class="category-card__media" id="inne-preview" aria-hidden="true"></div>
+              <div class="category-card__content">
+                <h3>Nietypowe realizacje</h3>
+                <p>Indywidualne projekty do biur, wnęk czy przestrzeni komercyjnych.</p>
+                <span class="category-card__cta">Zobacz realizacje</span>
+              </div>
+            </a>
+          </article>
+        </div>
       </div>
-    </div>
-  </section>
+    </section>
+
+    <section id="about" class="about section reveal">
+      <div class="container container--narrow">
+        <div class="section-heading section-heading--left">
+          <p class="section-eyebrow">O nas</p>
+          <h2>Rodzinna pracownia z sercem do drewna</h2>
+          <p class="section-lead">Łączymy tradycję stolarską z nowoczesnym wzornictwem, tworząc meble, które doskonale wpisują się w codzienność naszych klientów.</p>
+        </div>
+        <div class="about__content">
+          <div class="about__text">
+            <p>Każdy projekt zaczynamy od rozmowy i poznania rytmu życia domowników. Dzięki temu powstają meble, które idealnie odpowiadają na potrzeby użytkowników i harmonijnie współgrają z architekturą wnętrza.</p>
+            <p>Projektujemy kompleksowo – od koncepcji, przez dokumentację techniczną, po produkcję i montaż. Kontrolujemy każdy etap prac, dbając o spójność detali i najwyższą jakość wykończenia.</p>
+            <p>Wykorzystujemy naturalne materiały i rzemieślnicze techniki, aby meble służyły przez lata. Zaufanie klientów budujemy transparentną komunikacją i terminowością.</p>
+          </div>
+          <ul class="about__highlights" aria-label="Nasze wyróżniki">
+            <li><span aria-hidden="true">✓</span><span>Rzemiosło i precyzja detalu</span></li>
+            <li><span aria-hidden="true">✓</span><span>Naturalne materiały klasy premium</span></li>
+            <li><span aria-hidden="true">✓</span><span>Projekty dopasowane do stylu życia</span></li>
+            <li><span aria-hidden="true">✓</span><span>Pełna opieka od projektu po montaż</span></li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section id="testimonials" class="testimonials section reveal">
+      <div class="container container--wide">
+        <div class="section-heading">
+          <p class="section-eyebrow">Opinie klientów</p>
+          <h2>Docenione przez osoby, które nam zaufały</h2>
+          <p class="section-lead">Realizacje Vikimeble trafiają do domów w całej Polsce. Tak mówią o współpracy klienci, którzy wybrali nasze projekty.</p>
+        </div>
+        <div class="testimonials-carousel" role="region" aria-label="Opinie klientów">
+          <button type="button" class="testimonials-control testimonials-control--prev" aria-label="Poprzednia opinia" disabled>
+            <span aria-hidden="true">&#8592;</span>
+          </button>
+          <div class="testimonials-viewport">
+            <div class="testimonials-track" aria-live="polite"></div>
+          </div>
+          <button type="button" class="testimonials-control testimonials-control--next" aria-label="Następna opinia" disabled>
+            <span aria-hidden="true">&#8594;</span>
+          </button>
+        </div>
+        <p class="testimonials-empty" hidden>Wkrótce pojawią się tutaj pierwsze opinie.</p>
+      </div>
+    </section>
+
+    <section id="contact" class="contact section reveal">
+      <div class="container container--wide">
+        <div class="section-heading section-heading--left">
+          <p class="section-eyebrow">Kontakt</p>
+          <h2>Porozmawiajmy o Twojej przestrzeni</h2>
+          <p class="section-lead">Zostaw wiadomość, a przygotujemy wstępny plan działania i termin spotkania w showroomie lub online.</p>
+        </div>
+        <div class="contact-wrapper">
+          <form class="contact-form" aria-label="Formularz kontaktowy">
+            <label class="contact-field">
+              <span>Imię i nazwisko</span>
+              <input type="text" name="name" autocomplete="name" required />
+            </label>
+            <label class="contact-field">
+              <span>Adres e-mail</span>
+              <input type="email" name="email" autocomplete="email" required />
+            </label>
+            <label class="contact-field contact-field--textarea">
+              <span>Wiadomość</span>
+              <textarea name="message" rows="4" required></textarea>
+            </label>
+            <button type="submit" class="btn contact-submit">Wyślij wiadomość</button>
+          </form>
+          <div class="contact-info" aria-label="Dane kontaktowe">
+            <div class="contact-card">
+              <h3>Vikimeble</h3>
+              <p>Firma Produkcyjno-Usługowa Piotr Jedziniak</p>
+              <address>
+                39-208 Głobikowa 99<br />
+                Polska
+              </address>
+              <p>
+                <a href="tel:787138178" class="contact-link">tel. 787 138 178</a><br />
+                <a href="mailto:biuro@vikimeble.pl" class="contact-link">biuro@vikimeble.pl</a>
+              </p>
+            </div>
+            <div class="contact-card">
+              <h3>Godziny kontaktu</h3>
+              <p>Poniedziałek – Piątek: 8:00 – 17:00</p>
+              <p>Sobota: 9:00 – 13:00</p>
+              <p>Działamy na terenie całej Polski.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
 
   <footer class="footer">
-    <p>&copy; <span id="year"></span> Vikimeble</p>
-    <a href="/login">Panel administracyjny</a>
+    <div class="container container--wide">
+      <p>&copy; <span id="year"></span> Vikimeble</p>
+      <a href="/login" class="footer-link">Panel administracyjny</a>
+    </div>
   </footer>
 
   <script src="./js/menu.js"></script>

--- a/docs/js/main.js
+++ b/docs/js/main.js
@@ -1,16 +1,105 @@
-// Podglądy sekcji będą pobierane dynamicznie z API
+const navController = window.vikimebleNav || {};
+const navElement = navController.navElement || document.querySelector('.nav');
+const navLinks = Array.from(document.querySelectorAll('#primary-navigation a[href^="#"]'));
+const navToggle = document.querySelector('.menu-toggle');
+
+function closeNavMenu() {
+  if (typeof navController.close === 'function') {
+    navController.close();
+    return;
+  }
+  if (navElement && navElement.classList.contains('open')) {
+    navElement.classList.remove('open');
+    if (navToggle) {
+      navToggle.setAttribute('aria-expanded', 'false');
+    }
+  }
+}
+
+function enhanceAnchorNavigation() {
+  const sections = navLinks
+    .map(link => {
+      const id = link.hash.replace('#', '');
+      const section = document.getElementById(id);
+      return section ? { link, section, id } : null;
+    })
+    .filter(Boolean);
+
+  if (sections.length > 0) {
+    const initialId = sections[0].id;
+    navLinks.forEach(link => {
+      if (link.hash === `#${initialId}`) {
+        link.classList.add('is-active');
+      }
+    });
+  }
+
+  navLinks.forEach(link => {
+    const hash = link.hash;
+    if (!hash) return;
+    const target = document.querySelector(hash);
+    if (!target) return;
+    link.addEventListener('click', event => {
+      event.preventDefault();
+      target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      closeNavMenu();
+    });
+  });
+
+  if (!('IntersectionObserver' in window) || sections.length === 0) {
+    return;
+  }
+
+  const setActiveLink = id => {
+    navLinks.forEach(link => {
+      if (link.hash === `#${id}`) {
+        link.classList.add('is-active');
+      } else {
+        link.classList.remove('is-active');
+      }
+    });
+  };
+
+  const observer = new IntersectionObserver(entries => {
+    const visible = entries
+      .filter(entry => entry.isIntersecting)
+      .sort((a, b) => b.intersectionRatio - a.intersectionRatio);
+    if (visible.length) {
+      setActiveLink(visible[0].target.id);
+    }
+  }, { threshold: 0.55 });
+
+  sections.forEach(({ section }) => observer.observe(section));
+}
+
+enhanceAnchorNavigation();
+
+if (typeof navController.update === 'function') {
+  navController.update();
+}
 
 function renderPreview(sectionId, images, link) {
   const container = document.getElementById(sectionId);
   if (!container) return;
-  images.slice(0, 3).forEach(image => {
-    const a = document.createElement('a');
-    a.href = link;
+  container.innerHTML = '';
+  const limited = Array.isArray(images) ? images.slice(0, 3) : [];
+
+  if (typeof link === 'string') {
+    const wrapperLink = container.closest('a');
+    if (wrapperLink) {
+      wrapperLink.href = link;
+    }
+  }
+
+  limited.forEach(image => {
     const img = document.createElement('img');
     img.src = image.src;
-    img.alt = image.alt || '';
-    a.appendChild(img);
-    container.appendChild(a);
+    img.alt = image.alt || 'Realizacja Vikimeble';
+    img.loading = 'lazy';
+    img.decoding = 'async';
+    img.width = 480;
+    img.height = 360;
+    container.appendChild(img);
   });
 }
 
@@ -25,35 +114,250 @@ async function loadPreviews() {
 
   for (const { category, sectionId, link } of sections) {
     try {
-      const res = await fetch(`/api/gallery?category=${category}`);
+      const res = await fetch(`/api/gallery?category=${encodeURIComponent(category)}`, { cache: 'no-store' });
+      if (!res.ok) throw new Error(`Status ${res.status}`);
       const images = await res.json();
       renderPreview(sectionId, images, link);
-    } catch (err) {
-      console.error('Błąd pobierania galerii', err);
+    } catch (error) {
+      console.error('Błąd pobierania galerii', error);
     }
   }
 }
 
 loadPreviews();
 
-// Animacja pojawiania się sekcji
-const observer = new IntersectionObserver((entries) => {
+const revealObserver = new IntersectionObserver(entries => {
   entries.forEach(entry => {
     if (entry.isIntersecting) {
       entry.target.classList.add('active');
-      observer.unobserve(entry.target);
+      revealObserver.unobserve(entry.target);
     }
   });
 }, { threshold: 0.1 });
 
-document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
+document.querySelectorAll('.reveal').forEach(el => revealObserver.observe(el));
 
-// Obsługa formularza kontaktowego
-const form = document.querySelector('.contact-form');
-form.addEventListener('submit', (e) => {
-  e.preventDefault();
-  alert('Dziękujemy za wiadomość!');
-  form.reset();
+const contactForm = document.querySelector('.contact-form');
+if (contactForm) {
+  contactForm.addEventListener('submit', event => {
+    event.preventDefault();
+    alert('Dziękujemy za wiadomość!');
+    contactForm.reset();
+  });
+}
+
+const testimonialsState = {
+  items: [],
+  currentIndex: 0,
+  perView: 1,
+  cardWidth: 0,
+  gap: 0
+};
+
+const testimonialsTrack = document.querySelector('.testimonials-track');
+const testimonialsViewport = document.querySelector('.testimonials-viewport');
+const prevButton = document.querySelector('.testimonials-control--prev');
+const nextButton = document.querySelector('.testimonials-control--next');
+const testimonialsEmpty = document.querySelector('.testimonials-empty');
+let resizeTimer = null;
+
+function determinePerView() {
+  const width = window.innerWidth;
+  if (width >= 1024) return 3;
+  if (width >= 768) return 2;
+  return 1;
+}
+
+function syncPerView() {
+  const next = determinePerView();
+  if (next !== testimonialsState.perView) {
+    testimonialsState.perView = next;
+    const maxIndex = Math.max(0, testimonialsState.items.length - next);
+    testimonialsState.currentIndex = Math.min(testimonialsState.currentIndex, maxIndex);
+  }
+}
+
+function syncTrackDimensions() {
+  if (!testimonialsTrack || !testimonialsViewport) return;
+  const styles = getComputedStyle(testimonialsTrack);
+  const gapValue = parseFloat(styles.columnGap || styles.gap || '0');
+  const targetColumns = Math.max(1, testimonialsState.perView);
+  const visibleColumns = testimonialsState.items.length
+    ? Math.min(targetColumns, testimonialsState.items.length)
+    : targetColumns;
+  const viewportWidth = testimonialsViewport.clientWidth;
+  const baseColumns = Math.max(1, visibleColumns);
+  const cardWidth = Math.max(0, (viewportWidth - gapValue * (baseColumns - 1)) / baseColumns);
+  testimonialsState.cardWidth = cardWidth;
+  testimonialsState.gap = gapValue;
+  testimonialsTrack.querySelectorAll('.testimonial-card').forEach(card => {
+    card.style.width = `${cardWidth}px`;
+    card.style.maxWidth = `${cardWidth}px`;
+    card.style.minWidth = `${cardWidth}px`;
+  });
+}
+
+function updateCarouselControls() {
+  const maxIndex = Math.max(0, testimonialsState.items.length - testimonialsState.perView);
+  if (prevButton) {
+    prevButton.disabled = testimonialsState.currentIndex <= 0;
+  }
+  if (nextButton) {
+    nextButton.disabled = testimonialsState.currentIndex >= maxIndex;
+  }
+}
+
+function updateCarouselPosition() {
+  if (!testimonialsTrack) return;
+  const offset = testimonialsState.currentIndex * (testimonialsState.cardWidth + testimonialsState.gap);
+  testimonialsTrack.style.transform = `translateX(-${offset}px)`;
+  updateCarouselControls();
+}
+
+function createTestimonialCard(testimonial) {
+  const card = document.createElement('article');
+  card.className = 'testimonial-card';
+
+  if (testimonial.rating) {
+    const ratingWrapper = document.createElement('div');
+    ratingWrapper.className = 'testimonial-rating';
+    const stars = document.createElement('span');
+    const starCount = Math.max(1, Math.min(5, Math.round(Number(testimonial.rating)) || 0));
+    stars.textContent = '★'.repeat(starCount);
+    stars.setAttribute('aria-hidden', 'true');
+    const sr = document.createElement('span');
+    sr.className = 'visually-hidden';
+    sr.textContent = `Ocena: ${starCount} na 5`;
+    ratingWrapper.append(stars, sr);
+    card.appendChild(ratingWrapper);
+  }
+
+  const quote = document.createElement('p');
+  quote.className = 'testimonial-quote';
+  const content = (testimonial.quote || '').trim();
+  quote.textContent = content ? `„${content}”` : '';
+  card.appendChild(quote);
+
+  const author = document.createElement('p');
+  author.className = 'testimonial-author';
+  author.textContent = testimonial.author || 'Klient Vikimeble';
+  card.appendChild(author);
+
+  return card;
+}
+
+function renderTestimonials(items) {
+  if (!testimonialsTrack) return;
+  testimonialsTrack.innerHTML = '';
+
+  const validItems = Array.isArray(items) ? items : [];
+  testimonialsState.items = validItems;
+  testimonialsState.currentIndex = 0;
+
+  if (validItems.length === 0) {
+    if (testimonialsEmpty) testimonialsEmpty.hidden = false;
+    updateCarouselControls();
+    return;
+  }
+
+  if (testimonialsEmpty) testimonialsEmpty.hidden = true;
+
+  const fragment = document.createDocumentFragment();
+  validItems.forEach(item => fragment.appendChild(createTestimonialCard(item)));
+  testimonialsTrack.appendChild(fragment);
+
+  syncPerView();
+  syncTrackDimensions();
+  updateCarouselPosition();
+}
+
+function handleResize() {
+  syncPerView();
+  syncTrackDimensions();
+  updateCarouselPosition();
+}
+
+if (prevButton) {
+  prevButton.addEventListener('click', () => {
+    testimonialsState.currentIndex = Math.max(0, testimonialsState.currentIndex - testimonialsState.perView);
+    updateCarouselPosition();
+  });
+}
+
+if (nextButton) {
+  nextButton.addEventListener('click', () => {
+    const maxIndex = Math.max(0, testimonialsState.items.length - testimonialsState.perView);
+    testimonialsState.currentIndex = Math.min(maxIndex, testimonialsState.currentIndex + testimonialsState.perView);
+    updateCarouselPosition();
+  });
+}
+
+window.addEventListener('resize', () => {
+  if (resizeTimer) window.clearTimeout(resizeTimer);
+  resizeTimer = window.setTimeout(handleResize, 150);
 });
 
-document.getElementById('year').textContent = new Date().getFullYear();
+function injectReviewSchema(testimonials) {
+  const existing = document.getElementById('reviews-schema');
+  if (existing) existing.remove();
+  if (!Array.isArray(testimonials) || testimonials.length === 0) return;
+
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    itemReviewed: {
+      '@type': 'Organization',
+      name: 'Vikimeble'
+    },
+    itemListElement: testimonials.map((testimonial, index) => {
+      const review = {
+        '@type': 'Review',
+        author: {
+          '@type': 'Person',
+          name: testimonial.author || 'Klient Vikimeble'
+        },
+        reviewBody: testimonial.quote || ''
+      };
+      if (testimonial.rating) {
+        review.reviewRating = {
+          '@type': 'Rating',
+          ratingValue: Number(testimonial.rating),
+          bestRating: 5,
+          worstRating: 1
+        };
+      }
+      return {
+        '@type': 'ListItem',
+        position: index + 1,
+        item: review
+      };
+    })
+  };
+
+  const script = document.createElement('script');
+  script.type = 'application/ld+json';
+  script.id = 'reviews-schema';
+  script.textContent = JSON.stringify(schema);
+  document.head.appendChild(script);
+}
+
+async function loadTestimonials() {
+  if (!testimonialsTrack) return;
+  try {
+    const res = await fetch('/api/testimonials', { cache: 'no-store' });
+    if (!res.ok) throw new Error(`Status ${res.status}`);
+    const testimonials = await res.json();
+    renderTestimonials(testimonials);
+    injectReviewSchema(testimonials);
+  } catch (error) {
+    console.error('Nie udało się pobrać opinii', error);
+    renderTestimonials([]);
+  }
+}
+
+loadTestimonials();
+
+const yearPlaceholder = document.getElementById('year');
+if (yearPlaceholder) {
+  yearPlaceholder.textContent = new Date().getFullYear();
+}

--- a/docs/js/menu.js
+++ b/docs/js/menu.js
@@ -1,21 +1,127 @@
-// Dropdown menu toggle for mobile
 if (typeof document !== 'undefined') {
   const nav = document.querySelector('.nav');
   const toggle = document.querySelector('.menu-toggle');
+  const dropdownTriggers = Array.from(document.querySelectorAll('.dropdown > a'));
+  let lastWindowWidth = window.innerWidth;
+
+  const closeDropdowns = () => {
+    dropdownTriggers.forEach(trigger => {
+      const parent = trigger.parentElement;
+      if (parent) {
+        parent.classList.remove('open');
+      }
+      trigger.setAttribute('aria-expanded', 'false');
+    });
+  };
+
+  const closeNav = () => {
+    if (!nav) return;
+    if (nav.classList.contains('open')) {
+      nav.classList.remove('open');
+      if (toggle) {
+        toggle.setAttribute('aria-expanded', 'false');
+      }
+      closeDropdowns();
+    }
+  };
+
+  const openNav = () => {
+    if (!nav) return;
+    nav.classList.add('open');
+    if (toggle) {
+      toggle.setAttribute('aria-expanded', 'true');
+    }
+  };
 
   if (toggle && nav) {
     toggle.addEventListener('click', () => {
-      // Show or hide the navigation by toggling the `.open` class
-      nav.classList.toggle('open');
+      if (nav.classList.contains('open')) {
+        closeNav();
+      } else {
+        openNav();
+      }
     });
   }
 
-  document.querySelectorAll('.dropdown > a').forEach(btn => {
-    btn.addEventListener('click', e => {
+  dropdownTriggers.forEach(trigger => {
+    trigger.setAttribute('aria-expanded', 'false');
+    trigger.addEventListener('click', event => {
       if (window.innerWidth <= 768) {
-        e.preventDefault();
-        btn.parentElement.classList.toggle('open');
+        event.preventDefault();
+        const parent = trigger.parentElement;
+        if (!parent) return;
+        const isOpen = parent.classList.toggle('open');
+        trigger.setAttribute('aria-expanded', String(isOpen));
+      }
+    });
+
+    trigger.addEventListener('mouseenter', () => {
+      if (window.innerWidth > 768) {
+        trigger.setAttribute('aria-expanded', 'true');
+      }
+    });
+
+    trigger.addEventListener('mouseleave', () => {
+      if (window.innerWidth > 768) {
+        trigger.setAttribute('aria-expanded', 'false');
+      }
+    });
+
+    trigger.addEventListener('focus', () => {
+      if (window.innerWidth > 768) {
+        trigger.setAttribute('aria-expanded', 'true');
+      }
+    });
+
+    trigger.addEventListener('blur', () => {
+      if (window.innerWidth > 768) {
+        trigger.setAttribute('aria-expanded', 'false');
       }
     });
   });
+
+  if (nav) {
+    nav.querySelectorAll('a').forEach(link => {
+      link.addEventListener('click', () => {
+        if (window.innerWidth <= 768) {
+          closeNav();
+        }
+      });
+    });
+  }
+
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape') {
+      closeNav();
+    }
+  });
+
+  function updateNavAppearance() {
+    if (!nav || nav.classList.contains('nav--static')) return;
+    const hero = document.querySelector('.hero');
+    const threshold = hero ? Math.max(hero.offsetHeight * 0.45, 120) : 120;
+    if (window.scrollY > threshold) {
+      nav.classList.add('nav--solid');
+    } else {
+      nav.classList.remove('nav--solid');
+    }
+  }
+
+  updateNavAppearance();
+  window.addEventListener('scroll', updateNavAppearance, { passive: true });
+  window.addEventListener('resize', () => {
+    if (window.innerWidth !== lastWindowWidth) {
+      if (window.innerWidth > 768) {
+        closeNav();
+      }
+      lastWindowWidth = window.innerWidth;
+    }
+    updateNavAppearance();
+  });
+
+  window.vikimebleNav = {
+    close: closeNav,
+    navElement: nav,
+    update: updateNavAppearance
+  };
 }

--- a/server/testimonials.json
+++ b/server/testimonials.json
@@ -1,0 +1,18 @@
+[
+  {
+    "id": 1,
+    "author": "Anna",
+    "quote": "Stół od Vikimeble to dzieło sztuki.",
+    "rating": 5,
+    "published": true,
+    "order": 1
+  },
+  {
+    "id": 2,
+    "author": "Michał",
+    "quote": "Profesjonalna obsługa i jakość.",
+    "rating": 5,
+    "published": true,
+    "order": 2
+  }
+]


### PR DESCRIPTION
## Summary
- redesign the homepage hero, navigation, categories, about, contact and add a testimonials carousel backed by the API
- align global styling with subpages, improve accessibility, add lazy loading, and inject structured data for reviews
- implement testimonials storage with CRUD endpoints and extend the admin dashboard for managing testimonials

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d5c35c35d88324b79efe4084fdbd06